### PR TITLE
Mysql failover handling

### DIFF
--- a/ClickView.GoodStuff.sln
+++ b/ClickView.GoodStuff.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.Reposit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.Repositories.MsSql.Tests", "src\Repositories\MsSql\test\ClickView.GoodStuff.Repositories.MsSql.Tests\ClickView.GoodStuff.Repositories.MsSql.Tests.csproj", "{3756676A-A65F-4317-BE7B-E8514D679396}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.Repositories.MySql.TestApp", "src\Repositories\MySql\test\ClickView.GoodStuff.Repositories.MySql.TestApp\ClickView.GoodStuff.Repositories.MySql.TestApp.csproj", "{FCC9314F-2B3C-4DE2-A967-66A457090B74}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{3756676A-A65F-4317-BE7B-E8514D679396}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3756676A-A65F-4317-BE7B-E8514D679396}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3756676A-A65F-4317-BE7B-E8514D679396}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,6 +79,7 @@ Global
 		{38F6761B-FAA5-479C-9C68-2CA660164D36} = {17A5F05F-B3EB-4011-A58C-BB1BB7995692}
 		{EE991636-363C-4F8E-A783-C91B0281622C} = {38F6761B-FAA5-479C-9C68-2CA660164D36}
 		{3756676A-A65F-4317-BE7B-E8514D679396} = {38F6761B-FAA5-479C-9C68-2CA660164D36}
+		{FCC9314F-2B3C-4DE2-A967-66A457090B74} = {BBBCE886-F029-442F-AC97-EE52C7D64374}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F935033F-FAFD-48D4-843C-C7C8A9AE6562}

--- a/src/Repositories/Abstractions/src/BaseRepository.cs
+++ b/src/Repositories/Abstractions/src/BaseRepository.cs
@@ -1,5 +1,6 @@
 ﻿namespace ClickView.GoodStuff.Repositories.Abstractions
 {
+    using System;
     using Factories;
 
     public abstract class BaseRepository<TConnection>
@@ -8,6 +9,9 @@
 
         protected BaseRepository(IConnectionFactory<TConnection> connectionFactory)
         {
+            if (connectionFactory == null)
+                throw new ArgumentNullException(nameof(connectionFactory));
+
             _connectionFactory = connectionFactory;
         }
 

--- a/src/Repositories/MySql/src/ClickView.GoodStuff.Repositories.MySql.csproj
+++ b/src/Repositories/MySql/src/ClickView.GoodStuff.Repositories.MySql.csproj
@@ -10,6 +10,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Repositories/MySql/src/ClickView.GoodStuff.Repositories.MySql.csproj
+++ b/src/Repositories/MySql/src/ClickView.GoodStuff.Repositories.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <Version>0.0.9</Version>
     <Company>ClickView</Company>
     <Authors>ClickView</Authors>
@@ -15,7 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="MySqlConnector" Version="1.0.1" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Repositories/MySql/src/MySqlRepositoryOptions.cs
+++ b/src/Repositories/MySql/src/MySqlRepositoryOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace ClickView.GoodStuff.Repositories.MySql
+{
+    using System;
+    using Microsoft.Extensions.Logging;
+
+    public class MySqlRepositoryOptions
+    {
+        /// <summary>
+        /// The number of times to retry a query on a fail-over error
+        /// </summary>
+        public int FailOverRetryCount { get; set; } = 0;
+
+        /// <summary>
+        /// The function that provides the duration to wait for for a particular fail-over retry attempt
+        /// </summary>
+        public Func<int, TimeSpan> FailOverRetryTimeout { get; set; } = retry => TimeSpan.FromSeconds(retry * 2);
+
+        public ILoggerFactory LoggerFactory { get; set; }
+    }
+}

--- a/src/Repositories/MySql/src/MySqlRepositoryOptions.cs
+++ b/src/Repositories/MySql/src/MySqlRepositoryOptions.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// The function that provides the duration to wait for for a particular fail-over retry attempt
         /// </summary>
-        public Func<int, TimeSpan> FailOverRetryTimeout { get; set; } = retry => TimeSpan.FromSeconds(retry * 2);
+        public Func<int, TimeSpan> FailOverRetryTimeout { get; set; } = retry => TimeSpan.FromSeconds(2);
 
         public ILoggerFactory LoggerFactory { get; set; }
     }

--- a/src/Repositories/MySql/src/MySqlUtils.cs
+++ b/src/Repositories/MySql/src/MySqlUtils.cs
@@ -4,6 +4,11 @@
 
     public static class MySqlUtils
     {
+        /// <summary>
+        /// Checks if the provided <paramref name="mySqlException"/> is a failover exception
+        /// </summary>
+        /// <param name="mySqlException"></param>
+        /// <returns></returns>
         public static bool IsFailoverException(MySqlException mySqlException)
         {
             return mySqlException.Number == (int) MySqlErrorCode.UnableToConnectToHost ||

--- a/src/Repositories/MySql/src/MySqlUtils.cs
+++ b/src/Repositories/MySql/src/MySqlUtils.cs
@@ -1,0 +1,14 @@
+﻿namespace ClickView.GoodStuff.Repositories.MySql
+{
+    using MySqlConnector;
+
+    public static class MySqlUtils
+    {
+        public static bool IsFailoverException(MySqlException mySqlException)
+        {
+            return mySqlException.Number == (int) MySqlErrorCode.UnableToConnectToHost ||
+                   mySqlException.Number == (int) MySqlErrorCode.OptionPreventsStatement ||
+                   mySqlException.Number == 0 && mySqlException.HResult == -2147467259;
+        }
+    }
+}

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/ClickView.GoodStuff.Repositories.MySql.TestApp.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/ClickView.GoodStuff.Repositories.MySql.TestApp.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\ClickView.GoodStuff.Repositories.MySql.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
+    </ItemGroup>
+
+</Project>

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/Program.cs
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/Program.cs
@@ -1,0 +1,97 @@
+﻿namespace ClickView.GoodStuff.Repositories.MySql.TestApp
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Abstractions.Factories;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+
+    internal class Program
+    {
+        private const string Host = "";
+        private const string RootUser = "";
+        private const string RootPwd = "";
+
+        private static async Task Main(string[] args)
+        {
+            await SetupAsync();
+
+            var services = new ServiceCollection();
+            services.AddLogging(o => o.AddConsole());
+
+            var connection = new MySqlConnectionOptions
+            {
+                Host = Host,
+                Username = "testusr",
+                Password = "testpw",
+                Database = "test_db"
+            };
+
+            var connFactory = new MySqlConnectionFactory(new ConnectionFactoryOptions<MySqlConnectionOptions>
+            {
+                Write = connection,
+                Read = connection
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+            var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
+
+            var testRepo = new TestRepo(connFactory, new MySqlRepositoryOptions
+            {
+                FailOverRetryCount = 10,
+                LoggerFactory = loggerFactory
+            });
+
+            logger.LogInformation("Starting...");
+
+            if (args.Contains("-write"))
+            {
+                while (true)
+                {
+                    logger.LogInformation("Writing...");
+
+                    await testRepo.WriteAsync("INSERT IGNORE INTO `test_table` VALUES (1);");
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+
+            if (args.Contains("-read"))
+            {
+                while (true)
+                {
+                    logger.LogInformation("Reading...");
+
+                    await testRepo.ReadAsync<int>("SELECT * FROM `test_table`;");
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+        }
+
+        private static async Task SetupAsync()
+        {
+            var connFactory = new MySqlConnectionFactory(new ConnectionFactoryOptions<MySqlConnectionOptions>
+            {
+                Write = new MySqlConnectionOptions
+                {
+                    Host = Host,
+                    Username = RootUser,
+                    Password = RootPwd
+                }
+            });
+
+            var testRepo = new TestRepo(connFactory);
+
+            await testRepo.WriteAsync("CREATE SCHEMA IF NOT EXISTS test_db; " +
+                                      "CREATE TABLE IF NOT EXISTS `test_db`.`test_table` (id int PRIMARY KEY);" +
+                                      "CREATE USER IF NOT EXISTS 'testusr'@'%' IDENTIFIED BY 'testpw';" +
+                                      "GRANT INSERT,SELECT ON test_db.test_table TO 'testusr'@'%';" +
+                                      "FLUSH PRIVILEGES;"
+            );
+        }
+    }
+}

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/TestRepo.cs
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/TestRepo.cs
@@ -1,0 +1,27 @@
+﻿namespace ClickView.GoodStuff.Repositories.MySql.TestApp
+{
+    using System.Threading.Tasks;
+    using Abstractions.Factories;
+    using MySqlConnector;
+
+    public class TestRepo : BaseMySqlRepository
+    {
+        public TestRepo(IConnectionFactory<MySqlConnection> connectionFactory) : base(connectionFactory)
+        {
+        }
+
+        public TestRepo(IConnectionFactory<MySqlConnection> connectionFactory, MySqlRepositoryOptions options) : base(connectionFactory, options)
+        {
+        }
+
+        public Task ReadAsync<T>(string sql)
+        {
+            return QueryAsync<T>(sql);
+        }
+
+        public Task WriteAsync(string sql)
+        {
+            return ExecuteAsync(sql);
+        }
+    }
+}

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/TestRepo.cs
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/TestRepo.cs
@@ -1,16 +1,14 @@
 ﻿namespace ClickView.GoodStuff.Repositories.MySql.TestApp
 {
     using System.Threading.Tasks;
-    using Abstractions.Factories;
-    using MySqlConnector;
 
     public class TestRepo : BaseMySqlRepository
     {
-        public TestRepo(IConnectionFactory<MySqlConnection> connectionFactory) : base(connectionFactory)
+        public TestRepo(IMySqlConnectionFactory connectionFactory) : base(connectionFactory)
         {
         }
 
-        public TestRepo(IConnectionFactory<MySqlConnection> connectionFactory, MySqlRepositoryOptions options) : base(connectionFactory, options)
+        public TestRepo(IMySqlConnectionFactory connectionFactory, MySqlRepositoryOptions options) : base(connectionFactory, options)
         {
         }
 

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
@@ -3,10 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Added logic to be able to handle fail-overs from a mysql server (like aws rds). For now, the default is to not retry.
- Added a basic test app because I couldn't figure out how to unit test it (mysqlconnection is sealed)