### PR TITLE
Aspnetcore projects and version page middleware

### DIFF
--- a/ClickView.GoodStuff.sln
+++ b/ClickView.GoodStuff.sln
@@ -27,6 +27,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.Reposit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.Repositories.MySql.TestApp", "src\Repositories\MySql\test\ClickView.GoodStuff.Repositories.MySql.TestApp\ClickView.GoodStuff.Repositories.MySql.TestApp.csproj", "{FCC9314F-2B3C-4DE2-A967-66A457090B74}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AspNetCore", "AspNetCore", "{3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetCore.Abstractions", "src\AspNetCore\Abstractions\src\ClickView.GoodStuff.AspNetCore.Abstractions.csproj", "{F9B82DEF-2856-4C6D-9CC2-86B9BC669001}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetCore", "src\AspNetCore\AspNetCore\src\ClickView.GoodStuff.AspNetCore.csproj", "{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +71,14 @@ Global
 		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FCC9314F-2B3C-4DE2-A967-66A457090B74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9B82DEF-2856-4C6D-9CC2-86B9BC669001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9B82DEF-2856-4C6D-9CC2-86B9BC669001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9B82DEF-2856-4C6D-9CC2-86B9BC669001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9B82DEF-2856-4C6D-9CC2-86B9BC669001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,6 +94,8 @@ Global
 		{EE991636-363C-4F8E-A783-C91B0281622C} = {38F6761B-FAA5-479C-9C68-2CA660164D36}
 		{3756676A-A65F-4317-BE7B-E8514D679396} = {38F6761B-FAA5-479C-9C68-2CA660164D36}
 		{FCC9314F-2B3C-4DE2-A967-66A457090B74} = {BBBCE886-F029-442F-AC97-EE52C7D64374}
+		{F9B82DEF-2856-4C6D-9CC2-86B9BC669001} = {3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}
+		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7} = {3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F935033F-FAFD-48D4-843C-C7C8A9AE6562}

--- a/ClickView.GoodStuff.sln
+++ b/ClickView.GoodStuff.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetCore", "src\AspNetCore\AspNetCore\src\ClickView.GoodStuff.AspNetCore.csproj", "{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetCore.Tests", "src\AspNetCore\AspNetCore\test\ClickView.GoodStuff.AspNetCore.Tests.csproj", "{4E7C5178-8392-4BBF-9E48-606FDE5812E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E7C5178-8392-4BBF-9E48-606FDE5812E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E7C5178-8392-4BBF-9E48-606FDE5812E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E7C5178-8392-4BBF-9E48-606FDE5812E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E7C5178-8392-4BBF-9E48-606FDE5812E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +102,7 @@ Global
 		{FCC9314F-2B3C-4DE2-A967-66A457090B74} = {BBBCE886-F029-442F-AC97-EE52C7D64374}
 		{F9B82DEF-2856-4C6D-9CC2-86B9BC669001} = {3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}
 		{74A3CF27-CBE9-4C90-9AD5-E72440C320E7} = {3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}
+		{4E7C5178-8392-4BBF-9E48-606FDE5812E6} = {3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F935033F-FAFD-48D4-843C-C7C8A9AE6562}

--- a/src/AspNetCore/Abstractions/src/ClickView.GoodStuff.AspNetCore.Abstractions.csproj
+++ b/src/AspNetCore/Abstractions/src/ClickView.GoodStuff.AspNetCore.Abstractions.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/src/AspNetCore/AspNetCore/src/ApplicationInformation.cs
+++ b/src/AspNetCore/AspNetCore/src/ApplicationInformation.cs
@@ -1,16 +1,54 @@
 namespace ClickView.GoodStuff.AspNetCore
 {
     using System;
+    using System.Diagnostics;
+    using System.Reflection;
 
     public sealed class ApplicationInformation
     {
         public ApplicationInformation(string name, string version)
         {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            Version = version ?? throw new ArgumentNullException(nameof(version));
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Value cannot be empty", nameof(name));
+
+            if (string.IsNullOrWhiteSpace(version))
+                throw new ArgumentException("Value cannot be empty", nameof(version));
+
+            Name = name;
+            Version = version;
         }
 
         public string Name { get; }
         public string Version { get; }
+
+        public static ApplicationInformation FromAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            return FromFileVersion(FileVersionInfo.GetVersionInfo(assembly.Location));
+        }
+
+        public static ApplicationInformation FromFileVersion(FileVersionInfo fileVersionInfo)
+        {
+            if (fileVersionInfo == null)
+                throw new ArgumentNullException(nameof(fileVersionInfo));
+
+            if (string.IsNullOrWhiteSpace(fileVersionInfo.ProductName))
+            {
+                throw new ArgumentException(
+                    nameof(FileVersionInfo.ProductName) + " cannot be empty",
+                    nameof(fileVersionInfo));
+            }
+
+            if (string.IsNullOrWhiteSpace(fileVersionInfo.ProductVersion))
+            {
+                throw new ArgumentException(
+                    nameof(FileVersionInfo.ProductVersion) + " cannot be empty",
+                    nameof(fileVersionInfo));
+            }
+
+            return new ApplicationInformation(fileVersionInfo.ProductName, fileVersionInfo.ProductVersion);
+        }
     }
 }

--- a/src/AspNetCore/AspNetCore/src/ApplicationInformation.cs
+++ b/src/AspNetCore/AspNetCore/src/ApplicationInformation.cs
@@ -1,0 +1,16 @@
+namespace ClickView.GoodStuff.AspNetCore
+{
+    using System;
+
+    public sealed class ApplicationInformation
+    {
+        public ApplicationInformation(string name, string version)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Version = version ?? throw new ArgumentNullException(nameof(version));
+        }
+
+        public string Name { get; }
+        public string Version { get; }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
@@ -2,6 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
 
 </Project>

--- a/src/AspNetCore/AspNetCore/src/VersionPage/ApplicationBuilderExtensions.cs
+++ b/src/AspNetCore/AspNetCore/src/VersionPage/ApplicationBuilderExtensions.cs
@@ -1,0 +1,51 @@
+namespace ClickView.GoodStuff.AspNetCore.VersionPage
+{
+    using System;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Options;
+
+    public static class ApplicationBuilderExtensions
+    {
+        public static IApplicationBuilder UseVersionPage(this IApplicationBuilder app,
+            PathString path, ApplicationInformation information)
+        {
+            if (app == null)
+                throw new ArgumentNullException(nameof(app));
+
+            if (information == null)
+                throw new ArgumentNullException(nameof(information));
+
+            UseVersionPageCore(app, path, new object[] {information});
+
+            return app;
+        }
+
+        public static IApplicationBuilder UseVersionPage(this IApplicationBuilder app,
+            PathString path, ApplicationInformation information, VersionPageOptions options)
+        {
+            if (app == null)
+                throw new ArgumentNullException(nameof(app));
+
+            if (information == null)
+                throw new ArgumentNullException(nameof(information));
+
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            UseVersionPageCore(app, path, new object[] {information, Options.Create(options)});
+
+            return app;
+        }
+
+        private static void UseVersionPageCore(this IApplicationBuilder app,
+            PathString path, object[] args)
+        {
+            Func<HttpContext, bool> predicate = c =>
+                c.Request.Path.StartsWithSegments(path, out var remaining) &&
+                string.IsNullOrEmpty(remaining);
+
+            app.MapWhen(predicate, b => b.UseMiddleware<VersionPageMiddleware>(args));
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/VersionPage/ApplicationBuilderExtensions.cs
+++ b/src/AspNetCore/AspNetCore/src/VersionPage/ApplicationBuilderExtensions.cs
@@ -41,11 +41,10 @@ namespace ClickView.GoodStuff.AspNetCore.VersionPage
         private static void UseVersionPageCore(this IApplicationBuilder app,
             PathString path, object[] args)
         {
-            Func<HttpContext, bool> predicate = c =>
-                c.Request.Path.StartsWithSegments(path, out var remaining) &&
-                string.IsNullOrEmpty(remaining);
+            bool Predicate(HttpContext c) => c.Request.Path.StartsWithSegments(path, out var remaining) &&
+                                             string.IsNullOrEmpty(remaining);
 
-            app.MapWhen(predicate, b => b.UseMiddleware<VersionPageMiddleware>(args));
+            app.MapWhen(Predicate, b => b.UseMiddleware<VersionPageMiddleware>(args));
         }
     }
 }

--- a/src/AspNetCore/AspNetCore/src/VersionPage/VersionPageMiddleware.cs
+++ b/src/AspNetCore/AspNetCore/src/VersionPage/VersionPageMiddleware.cs
@@ -1,0 +1,42 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.VersionPage
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Options;
+
+    public sealed class VersionPageMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ApplicationInformation _applicationInformation;
+        private readonly VersionPageOptions _options;
+
+        public VersionPageMiddleware(
+            RequestDelegate next, ApplicationInformation applicationInformation, IOptions<VersionPageOptions> options)
+        {
+            if (next == null)
+                throw new ArgumentNullException(nameof(next));
+
+            if (applicationInformation == null)
+                throw new ArgumentNullException(nameof(applicationInformation));
+
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            _next = next;
+            _applicationInformation = applicationInformation;
+            _options = options.Value;
+        }
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            if (httpContext == null)
+                throw new ArgumentNullException(nameof(httpContext));
+
+            httpContext.Response.StatusCode = 200;
+
+            if (_options.ResponseWriter != null)
+                await _options.ResponseWriter(httpContext, _applicationInformation);
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/VersionPage/VersionPageOptions.cs
+++ b/src/AspNetCore/AspNetCore/src/VersionPage/VersionPageOptions.cs
@@ -1,0 +1,15 @@
+namespace ClickView.GoodStuff.AspNetCore.VersionPage
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+
+    public class VersionPageOptions
+    {
+        /// <summary>
+        /// Gets or sets a delegate used to write the response.
+        /// </summary>
+        public Func<HttpContext, ApplicationInformation, Task>? ResponseWriter { get; set; } =
+            VersionPageResponseWriters.WriteMinimalPlaintext;
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/VersionPage/VersionPageResponseWriters.cs
+++ b/src/AspNetCore/AspNetCore/src/VersionPage/VersionPageResponseWriters.cs
@@ -1,0 +1,21 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.VersionPage
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+
+    internal static class VersionPageResponseWriters
+    {
+        internal static Task WriteMinimalPlaintext(HttpContext httpContext, ApplicationInformation information)
+        {
+            httpContext.Response.ContentType = "text/plain; charset=utf-8";
+
+            // https://www.ietf.org/rfc/rfc2046.txt (4.1.1)
+            // new line as crlf
+            const string newLine = "\r\n";
+
+            var response = information.Name + newLine + "Version: " + information.Version;
+
+            return httpContext.Response.WriteAsync(response);
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/test/ApplicationInformationTests.cs
+++ b/src/AspNetCore/AspNetCore/test/ApplicationInformationTests.cs
@@ -1,0 +1,14 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.Tests
+{
+    using System;
+    using Xunit;
+
+    public class ApplicationInformationTests
+    {
+        [Fact]
+        public void FromAssembly_Null_ThrowsNullArgumentException()
+        {
+            Assert.Throws<ArgumentNullException>(() => ApplicationInformation.FromAssembly(null!));
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
+++ b/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ClickView.GoodStuff.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Added `ClickView.GoodStuff.AspNetCore` project
- Added `ClickView.GoodStuff.AspNetCore.Abstractions` project (currently empty)
- Added `VersionPage` middleware
  - Used by adding `UseVersionPage()` on `IApplicationBuilder`