### PR TITLE
Ajax helpers

### DIFF
--- a/src/AspNetCore/AspNetCore/src/AjaxControllerAttribute.cs
+++ b/src/AspNetCore/AspNetCore/src/AjaxControllerAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace ClickView.GoodStuff.AspNetCore
+{
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// Attribute to denote that the controller is used to serve Ajax requests
+    /// </summary>
+    public class AjaxControllerAttribute : ApiControllerAttribute
+    {
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/Authorization/AjaxAuthorizationMiddlewareResultHandler.cs
+++ b/src/AspNetCore/AspNetCore/src/Authorization/AjaxAuthorizationMiddlewareResultHandler.cs
@@ -1,0 +1,56 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.Authorization
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Authorization.Policy;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// A <see cref="IAuthorizationMiddlewareResultHandler"/> handler which will make controllers with the
+    /// <see cref="AjaxControllerAttribute"/> attribute return 401 or 403 status codes for challenged or forbidden requests
+    /// </summary>
+    public class AjaxAuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
+    {
+        private readonly AuthorizationMiddlewareResultHandler _handler;
+
+        /// <summary>
+        /// Create a new instance of <see cref="AjaxAuthorizationMiddlewareResultHandler"/>
+        /// </summary>
+        public AjaxAuthorizationMiddlewareResultHandler()
+        {
+            _handler = new AuthorizationMiddlewareResultHandler();
+        }
+
+        /// <inheritdoc />
+        public Task HandleAsync(RequestDelegate next, HttpContext context, AuthorizationPolicy policy,
+            PolicyAuthorizationResult authorizeResult)
+        {
+            var endpoint = context.GetEndpoint();
+
+            // If we have no endpoint, fall back to the default handler
+            if (endpoint == null)
+                return _handler.HandleAsync(next, context, policy, authorizeResult);
+
+            var ajaxAttribute = endpoint.Metadata.GetMetadata<AjaxControllerAttribute>();
+
+            // If we have attribute endpoint, fall back to the default handler
+            if (ajaxAttribute == null)
+                return _handler.HandleAsync(next, context, policy, authorizeResult);
+
+            if (authorizeResult.Challenged)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return Task.CompletedTask;
+            }
+
+            if (authorizeResult.Forbidden)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return Task.CompletedTask;
+            }
+
+            // Fall back to the default handler
+            return _handler.HandleAsync(next, context, policy, authorizeResult);
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/Authorization/AjaxAuthorizationMiddlewareResultHandler.cs
+++ b/src/AspNetCore/AspNetCore/src/Authorization/AjaxAuthorizationMiddlewareResultHandler.cs
@@ -33,7 +33,7 @@
 
             var ajaxAttribute = endpoint.Metadata.GetMetadata<AjaxControllerAttribute>();
 
-            // If we have attribute endpoint, fall back to the default handler
+            // If we have no attribute, fall back to the default handler
             if (ajaxAttribute == null)
                 return _handler.HandleAsync(next, context, policy, authorizeResult);
 

--- a/src/AspNetCore/AspNetCore/src/Authorization/ServiceCollectionExtensions.cs
+++ b/src/AspNetCore/AspNetCore/src/Authorization/ServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.Authorization
+{
+    using System;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Extension methods for <see cref="IServiceCollection"/>
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Register services to support ajax requests
+        /// </summary>
+        /// <param name="services"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static void AddAjaxServices(this IServiceCollection services)
+        {
+            if (services == null)
+                throw new ArgumentNullException(nameof(services));
+
+            // Register the 401/403 handler
+            services.AddTransient<IAuthorizationMiddlewareResultHandler, AjaxAuthorizationMiddlewareResultHandler>();
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <Version>1.0.0</Version>

--- a/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
+++ b/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/AspNetCore/Authentication/Abstractions/src/ClickView.GoodStuff.AspNetCore.Authentication.Abstractions.csproj
+++ b/src/AspNetCore/Authentication/Abstractions/src/ClickView.GoodStuff.AspNetCore.Authentication.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <Version>1.0.0</Version>

--- a/src/AspNetCore/Authentication/Authentication/src/ClickView.GoodStuff.AspNetCore.Authentication.csproj
+++ b/src/AspNetCore/Authentication/Authentication/src/ClickView.GoodStuff.AspNetCore.Authentication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <Version>1.0.0</Version>

--- a/src/AspNetCore/Authentication/StackExchangeRedis/src/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.csproj
+++ b/src/AspNetCore/Authentication/StackExchangeRedis/src/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <Version>1.0.0</Version>

--- a/src/AspNetCore/Authentication/StackExchangeRedis/test/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.Tests.csproj
+++ b/src/AspNetCore/Authentication/StackExchangeRedis/test/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Changes
- Upgrade aspnet projects to `.net5.0`
- Added handler which will convert aspnet responses that are either `Challenged` or `Forbidden` to 401 or 403 responses respectively

## Usage
```cs
services.AddAjaxServices()
```

then add the `AjaxController` attribute to any controller/action which returns ajax responses

## Use-case
For web apps, by default any request for any request that is unauthenticated will redirect the request to the login page. The included `AjaxAuthorizationMiddlewareResultHandler` in this MR will now make the response return a 401 instead