### PR TITLE
Add middleware which adds default headers to responses

### DIFF
--- a/src/AspNetCore/AspNetCore/src/Middleware/DefaultHeaders/ApplicationBuilderExtensions.cs
+++ b/src/AspNetCore/AspNetCore/src/Middleware/DefaultHeaders/ApplicationBuilderExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.Middleware.DefaultHeaders
+{
+    using System;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// Extension methods for adding default headers to the application
+    /// </summary>
+    public static class ApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// Adds middleware that adds default headers to the responses
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="options"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static void UseDefaultHeaders(this IApplicationBuilder app,
+            DefaultHeadersMiddlewareOptions options)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            app.UseMiddleware<DefaultHeadersMiddleware>(Options.Create(options));
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/Middleware/DefaultHeaders/DefaultHeadersMiddleware.cs
+++ b/src/AspNetCore/AspNetCore/src/Middleware/DefaultHeaders/DefaultHeadersMiddleware.cs
@@ -1,0 +1,50 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.Middleware.DefaultHeaders
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// Middleware to add a set of default headers specified in <see cref="DefaultHeadersMiddlewareOptions"/> to every response
+    /// </summary>
+    public class DefaultHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly DefaultHeadersMiddlewareOptions _options;
+
+        /// <summary>
+        /// Creates a new <see cref="DefaultHeadersMiddleware"/>
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="options"></param>
+        public DefaultHeadersMiddleware(RequestDelegate next, IOptions<DefaultHeadersMiddlewareOptions> options)
+        {
+            _next = next;
+            _options = options.Value;
+        }
+
+        /// <summary>
+        /// Invokes the logic of the middleware
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public Task Invoke(HttpContext context)
+        {
+            if (_options.DefaultHeaders.Count == 0)
+                return _next(context);
+
+            context.Response.OnStarting(() =>
+            {
+                foreach (var (key, value) in _options.DefaultHeaders)
+                {
+                    context.Response.Headers.TryAdd(key, value);
+                }
+
+                return Task.CompletedTask;
+            });
+
+            return _next(context);
+        }
+    }
+}

--- a/src/AspNetCore/AspNetCore/src/Middleware/DefaultHeaders/DefaultHeadersMiddlewareOptions.cs
+++ b/src/AspNetCore/AspNetCore/src/Middleware/DefaultHeaders/DefaultHeadersMiddlewareOptions.cs
@@ -1,0 +1,23 @@
+﻿namespace ClickView.GoodStuff.AspNetCore.Middleware.DefaultHeaders
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Primitives;
+
+    /// <summary>
+    /// Options for <see cref="DefaultHeadersMiddleware"/>
+    /// </summary>
+    public class DefaultHeadersMiddlewareOptions
+    {
+        private IDictionary<string, StringValues> _defaultHeaders = new Dictionary<string, StringValues>();
+
+        /// <summary>
+        /// The collection of default headers
+        /// </summary>
+        public IDictionary<string, StringValues> DefaultHeaders
+        {
+            get => _defaultHeaders;
+            set => _defaultHeaders = value ?? throw new ArgumentNullException(nameof(value));
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Add middleware which adds default headers to responses

## Usage
```cs
app.UseDefaultHeaders(o => 
{
    o.DefaultHeaders.Add("nice", "value");
});
```