### PR TITLE
Idlong updates

### DIFF
--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -1,4 +1,4 @@
-﻿namespace ClickView.GoodStuff.IdGenerators.Abstractions;
+namespace ClickView.GoodStuff.IdGenerators.Abstractions;
 
 using System;
 
@@ -42,7 +42,7 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
 #if NETSTANDARD2_0
             var idPart = value.Substring(1);
 #else
-            var idPart = value[1..];
+            var idPart = value.AsSpan(1);
 #endif
 
             return new IdLong(long.Parse(idPart));

--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -37,7 +37,7 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
         if (value is null)
             throw new ArgumentNullException(nameof(value));
 
-        if (value[0] == Prefix)
+        if (value.Length > 0 && value[0] == Prefix)
         {
 #if NETSTANDARD2_0
             var idPart = value.Substring(1);

--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -5,7 +5,7 @@ using System;
 /// <summary>
 /// Id which is based on a <see cref="long"/>
 /// </summary>
-public readonly struct IdLong: IComparable, IComparable<IdLong>, IEquatable<IdLong>
+public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdLong>
 {
     private const char Prefix = '_';
 
@@ -104,21 +104,21 @@ public readonly struct IdLong: IComparable, IComparable<IdLong>, IEquatable<IdLo
     }
 
     /// <summary>
-    /// Implicitly returns the inner <see cref="long"/> value
+    /// Explicitly returns the inner <see cref="long"/> value
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    public static implicit operator long(IdLong value)
+    public static explicit operator long(IdLong value)
     {
         return value._value;
     }
 
     /// <summary>
-    /// Implicitly creates a new <see cref="IdLong"/> from the given <paramref name="value"/>
+    /// Explicitly creates a new <see cref="IdLong"/> from the given <paramref name="value"/>
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    public static implicit operator IdLong(long value)
+    public static explicit operator IdLong(long value)
     {
         return new IdLong(value);
     }

--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -10,7 +10,10 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
 {
     private const char Prefix = '_';
 
-    private readonly long _value;
+    /// <summary>
+    /// The inner <see cref="long"/> value of the <see cref="IdLong"/>
+    /// </summary>
+    public long Value { get; }
 
     /// <summary>
     /// Create a new instance of <see cref="IdLong"/> with the given <paramref name="value"/>
@@ -18,7 +21,7 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
     /// <param name="value"></param>
     public IdLong(long value)
     {
-        _value = value;
+        Value = value;
     }
 
     /// <summary>
@@ -93,8 +96,8 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
         // to positive for very large neg numbers, etc.
         if (value is IdLong i)
         {
-            if (_value < i._value) return -1;
-            if (_value > i._value) return 1;
+            if (Value < i.Value) return -1;
+            if (Value > i.Value) return 1;
             return 0;
         }
 
@@ -106,15 +109,15 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
     {
         // Need to use compare because subtraction will wrap
         // to positive for very large neg numbers, etc.
-        if (_value < other._value) return -1;
-        if (_value > other._value) return 1;
+        if (Value < other.Value) return -1;
+        if (Value > other.Value) return 1;
         return 0;
     }
 
     /// <inheritdoc />
     public bool Equals(IdLong other)
     {
-        return _value == other._value;
+        return Value == other.Value;
     }
 
     /// <inheritdoc />
@@ -126,13 +129,13 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return _value.GetHashCode();
+        return Value.GetHashCode();
     }
 
     /// <inheritdoc />
     public override string ToString()
     {
-        return Prefix + _value.ToString();
+        return Prefix + Value.ToString();
     }
 
     /// <summary>
@@ -142,7 +145,7 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
     /// <returns></returns>
     public static explicit operator long(IdLong value)
     {
-        return value._value;
+        return value.Value;
     }
 
     /// <summary>

--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -1,6 +1,7 @@
-namespace ClickView.GoodStuff.IdGenerators.Abstractions;
+﻿namespace ClickView.GoodStuff.IdGenerators.Abstractions;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Id which is based on a <see cref="long"/>
@@ -49,6 +50,37 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
         }
 
         throw new FormatException("Invalid string");
+    }
+
+    /// <summary>
+    /// Try to parse a <see cref="IdLong"/> from a string. A return value indicates whether the conversion succeeded or failed.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <param name="result"></param>
+    /// <returns></returns>
+#if NETSTANDARD2_0
+    public static bool TryParse(string? value, out IdLong result)
+#else
+    public static bool TryParse([NotNullWhen(true)] string? value, out IdLong result)
+#endif
+    {
+        if (value is { Length: > 0 } && value[0] == Prefix)
+        {
+#if NETSTANDARD2_0
+            var idPart = value.Substring(1);
+#else
+            var idPart = value.AsSpan(1);
+#endif
+
+            if (long.TryParse(idPart, out var longValue))
+            {
+                result = new IdLong(longValue);
+                return true;
+            }
+        }
+
+        result = Empty;
+        return false;
     }
 
     /// <inheritdoc />

--- a/src/IdGenerators/Abstractions/test/IdLongTests.cs
+++ b/src/IdGenerators/Abstractions/test/IdLongTests.cs
@@ -56,4 +56,11 @@ public class IdLongTests
     {
         Assert.NotEqual(new IdLong(455), new IdLong(555));
     }
+
+    [Fact]
+    public void Value_Returns()
+    {
+        var id = new IdLong(666);
+        Assert.Equal(666, id.Value);
+    }
 }

--- a/src/IdGenerators/Abstractions/test/IdLongTests.cs
+++ b/src/IdGenerators/Abstractions/test/IdLongTests.cs
@@ -30,6 +30,22 @@ public class IdLongTests
     }
 
     [Fact]
+    public void TryParse_ReturnsTrue()
+    {
+        Assert.True(IdLong.TryParse("_1234", out var value));
+        Assert.Equal(1234, (long)value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("1234")]
+    [InlineData("")]
+    public void TryParse_MalformedId_ReturnsFalse(string? str)
+    {
+        Assert.False(IdLong.TryParse(str, out _));
+    }
+
+    [Fact]
     public void Compare_SameValue_Equal()
     {
         Assert.Equal(new IdLong(555), new IdLong(555));

--- a/src/IdGenerators/Abstractions/test/IdLongTests.cs
+++ b/src/IdGenerators/Abstractions/test/IdLongTests.cs
@@ -21,10 +21,12 @@ public class IdLongTests
         Assert.Equal(1234, (long)id);
     }
 
-    [Fact]
-    public void Parse_MalformedId_ThrowsFormatException()
+    [Theory]
+    [InlineData("1234")]
+    [InlineData("")]
+    public void Parse_MalformedId_ThrowsFormatException(string str)
     {
-        Assert.Throws<FormatException>(() => IdLong.Parse("1234"));
+        Assert.Throws<FormatException>(() => IdLong.Parse(str));
     }
 
     [Fact]

--- a/src/IdGenerators/Abstractions/test/IdLongTests.cs
+++ b/src/IdGenerators/Abstractions/test/IdLongTests.cs
@@ -18,7 +18,7 @@ public class IdLongTests
     {
         var id = IdLong.Parse("_1234");
 
-        Assert.Equal(1234, id);
+        Assert.Equal(1234, (long)id);
     }
 
     [Fact]


### PR DESCRIPTION
# IdLong
- Change implicit operator to explicit
- Use span instead of range to avoid extra allocations
- Fix `Parse` throwing the wrong exception for empty strings
- Add `TryParse`
- Expose the inner long value via `.Value`