### PR TITLE
ClickView.GoodStuff.Queues.RabbitMQ

### DIFF
--- a/ClickView.GoodStuff.sln
+++ b/ClickView.GoodStuff.sln
@@ -81,6 +81,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.AspNetCore.MaxMind.Tests", "src\AspNetCore\MaxMind\test\ClickView.GoodStuff.AspNetCore.MaxMind.Tests.csproj", "{7A661646-E121-4B09-AAF8-2D3173193585}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Queues", "Queues", "{41CD17D6-2B4C-4E27-9ABB-D21A6276BE7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.GoodStuff.Queues.RabbitMq", "src\Queues\RabbitMq\src\ClickView.GoodStuff.Queues.RabbitMq.csproj", "{B3CB4EF7-91A9-42E3-8174-590CC1CE5209}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -171,6 +175,10 @@ Global
 		{7A661646-E121-4B09-AAF8-2D3173193585}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A661646-E121-4B09-AAF8-2D3173193585}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A661646-E121-4B09-AAF8-2D3173193585}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3CB4EF7-91A9-42E3-8174-590CC1CE5209}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3CB4EF7-91A9-42E3-8174-590CC1CE5209}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3CB4EF7-91A9-42E3-8174-590CC1CE5209}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3CB4EF7-91A9-42E3-8174-590CC1CE5209}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -206,6 +214,7 @@ Global
 		{1397DF9B-D909-42D0-A789-9696918D9096} = {3D5037A8-592E-4EF8-AAC4-BA763CACBF1B}
 		{3D8D61D6-49FF-4CE4-8636-5EB6AC9F45BB} = {1397DF9B-D909-42D0-A789-9696918D9096}
 		{7A661646-E121-4B09-AAF8-2D3173193585} = {1397DF9B-D909-42D0-A789-9696918D9096}
+		{B3CB4EF7-91A9-42E3-8174-590CC1CE5209} = {41CD17D6-2B4C-4E27-9ABB-D21A6276BE7A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F935033F-FAFD-48D4-843C-C7C8A9AE6562}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,5 @@
         <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
-        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,5 +17,6 @@
         <LangVersion>10.0</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 </Project>

--- a/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
+++ b/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
+++ b/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />

--- a/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
+++ b/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>12</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
+++ b/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Queues/RabbitMq/src/EnqueueOptions.cs
+++ b/src/Queues/RabbitMq/src/EnqueueOptions.cs
@@ -3,7 +3,7 @@ namespace ClickView.GoodStuff.Queues.RabbitMq;
 public class EnqueueOptions
 {
     public bool Persistent { get; init; }
-    public string? RoutingKey { get; init; }
+    public string RoutingKey { get; init; } = string.Empty;
 
     internal static readonly EnqueueOptions Default = new();
 }

--- a/src/Queues/RabbitMq/src/EnqueueOptions.cs
+++ b/src/Queues/RabbitMq/src/EnqueueOptions.cs
@@ -1,0 +1,9 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public class EnqueueOptions
+{
+    public bool Persistent { get; init; }
+    public string? RoutingKey { get; init; }
+
+    internal static readonly EnqueueOptions Default = new();
+}

--- a/src/Queues/RabbitMq/src/IQueueClient.cs
+++ b/src/Queues/RabbitMq/src/IQueueClient.cs
@@ -1,6 +1,6 @@
 namespace ClickView.GoodStuff.Queues.RabbitMq;
 
-public interface IQueueClient
+public interface IQueueClient : IAsyncDisposable
 {
     Task EnqueueAsync<TData>(string exchange, TData data, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default);
@@ -9,4 +9,6 @@ public interface IQueueClient
         Func<MessageContext<TData>, CancellationToken, Task> callback,
         SubscribeOptions? options = null,
         CancellationToken cancellationToken = default);
+
+    Task UnsubscribeAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Queues/RabbitMq/src/IQueueClient.cs
+++ b/src/Queues/RabbitMq/src/IQueueClient.cs
@@ -1,0 +1,12 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public interface IQueueClient
+{
+    Task EnqueueAsync<TData>(string exchange, TData data, EnqueueOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    Task<SubscriptionContext> SubscribeAsync<TData>(string queue,
+        Func<MessageContext<TData>, CancellationToken, Task> callback,
+        SubscribeOptions? options = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Queues/RabbitMq/src/IQueueClient.cs
+++ b/src/Queues/RabbitMq/src/IQueueClient.cs
@@ -2,13 +2,44 @@ namespace ClickView.GoodStuff.Queues.RabbitMq;
 
 public interface IQueueClient : IAsyncDisposable
 {
+    /// <summary>
+    /// Connects to the Queue.
+    /// This is not required as the client will auto connect, but is useful for forcing a connection.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task ConnectAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Enqueues a message into an exchange.
+    /// </summary>
+    /// <param name="exchange">The name of the exchange</param>
+    /// <param name="data">The data to enqueue</param>
+    /// <param name="options">Additional enqueue options</param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="TData"></typeparam>
+    /// <returns></returns>
     Task EnqueueAsync<TData>(string exchange, TData data, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Subscribes to a queue.
+    /// </summary>
+    /// <param name="queue">The name of the queue</param>
+    /// <param name="callback">A callback function which is called when a new message is received</param>
+    /// <param name="options">Additional subscription options</param>
+    /// <param name="cancellationToken"></param>
+    /// <typeparam name="TData"></typeparam>
+    /// <returns>A subscription context. Dispose this to unsubscribe from the queue</returns>
     Task<SubscriptionContext> SubscribeAsync<TData>(string queue,
         Func<MessageContext<TData>, CancellationToken, Task> callback,
         SubscribeOptions? options = null,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Unsubscribes all active subscriptions.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     Task UnsubscribeAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Queues/RabbitMq/src/Internal/ActiveSubscriptions.cs
+++ b/src/Queues/RabbitMq/src/Internal/ActiveSubscriptions.cs
@@ -17,7 +17,7 @@ internal class ActiveSubscriptions
             _list.Remove(context);
     }
 
-    public IEnumerable<SubscriptionContext> GetAll()
+    public IReadOnlyCollection<SubscriptionContext> GetAll()
     {
         lock (_lock)
             return _list.ToList();

--- a/src/Queues/RabbitMq/src/Internal/ActiveSubscriptions.cs
+++ b/src/Queues/RabbitMq/src/Internal/ActiveSubscriptions.cs
@@ -11,10 +11,10 @@ internal class ActiveSubscriptions
             _list.Add(context);
     }
 
-    public void Remove(SubscriptionContext context)
+    public bool Remove(SubscriptionContext context)
     {
         lock (_lock)
-            _list.Remove(context);
+            return _list.Remove(context);
     }
 
     public IReadOnlyCollection<SubscriptionContext> GetAll()

--- a/src/Queues/RabbitMq/src/Internal/ActiveSubscriptions.cs
+++ b/src/Queues/RabbitMq/src/Internal/ActiveSubscriptions.cs
@@ -1,0 +1,25 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Internal;
+
+internal class ActiveSubscriptions
+{
+    private readonly List<SubscriptionContext> _list = new();
+    private readonly object _lock = new();
+
+    public void Add(SubscriptionContext context)
+    {
+        lock (_lock)
+            _list.Add(context);
+    }
+
+    public void Remove(SubscriptionContext context)
+    {
+        lock (_lock)
+            _list.Remove(context);
+    }
+
+    public IEnumerable<SubscriptionContext> GetAll()
+    {
+        lock (_lock)
+            return _list.ToList();
+    }
+}

--- a/src/Queues/RabbitMq/src/Internal/CountWaiter.cs
+++ b/src/Queues/RabbitMq/src/Internal/CountWaiter.cs
@@ -1,0 +1,45 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Internal;
+
+/// <summary>
+/// Allows waiting for a count to reach 0
+/// </summary>
+internal class CountWaiter
+{
+    private readonly object _pendingLock = new();
+    private List<TaskCompletionSource> _pendingAwaiters = new();
+    private int _count;
+
+    public Task WaitAsync()
+    {
+        if (_count == 0)
+            return Task.CompletedTask;
+
+        var tcs = new TaskCompletionSource();
+
+        lock (_pendingLock)
+            _pendingAwaiters.Add(tcs);
+
+        return tcs.Task;
+    }
+
+    public void Increment()
+    {
+        Interlocked.Increment(ref _count);
+    }
+
+    public void Decrement()
+    {
+        if (Interlocked.Decrement(ref _count) != 0) return;
+
+        lock (_pendingLock)
+        {
+            if (_pendingAwaiters.Count > 0)
+            {
+                foreach (var awaiter in _pendingAwaiters)
+                    awaiter.SetResult();
+
+                _pendingAwaiters.Clear();
+            }
+        }
+    }
+}

--- a/src/Queues/RabbitMq/src/Internal/CountWaiter.cs
+++ b/src/Queues/RabbitMq/src/Internal/CountWaiter.cs
@@ -33,13 +33,12 @@ internal class CountWaiter
 
         lock (_pendingLock)
         {
-            if (_pendingAwaiters.Count > 0)
-            {
-                foreach (var awaiter in _pendingAwaiters)
-                    awaiter.SetResult();
+            if (_pendingAwaiters.Count <= 0) return;
 
-                _pendingAwaiters.Clear();
-            }
+            foreach (var awaiter in _pendingAwaiters)
+                awaiter.SetResult();
+
+            _pendingAwaiters.Clear();
         }
     }
 }

--- a/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
@@ -1,0 +1,39 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Internal;
+
+using RabbitMQ.Client;
+using Serialization;
+
+internal class RabbitMqCallbackConsumer<TData> : AsyncDefaultBasicConsumer
+{
+    private readonly SubscriptionContext _subscriptionContext;
+    private readonly Func<MessageContext<TData>, CancellationToken, Task> _callback;
+    private readonly IMessageSerializer _serializer;
+
+    public RabbitMqCallbackConsumer(SubscriptionContext subscriptionContext,
+        Func<MessageContext<TData>, CancellationToken, Task> callback,
+        IMessageSerializer serializer)
+    {
+        _subscriptionContext = subscriptionContext;
+        _callback = callback;
+        _serializer = serializer;
+    }
+
+    public override async Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
+        string exchange, string routingKey, IBasicProperties properties, ReadOnlyMemory<byte> body)
+    {
+        var message = _serializer.Deserialize<TData>(body.Span);
+
+        if (message is null)
+            throw new RabbitMqClientException("Failed to deserialize message");
+
+        var context = new MessageContext<TData>(
+            data: message.Data,
+            deliveryTag: deliveryTag,
+            timestamp: DateTimeOffset.FromUnixTimeSeconds(message.Timestamp).UtcDateTime,
+            id: message.Id,
+            subscriptionContext: _subscriptionContext
+        );
+
+        await _callback(context, CancellationToken.None);
+    }
+}

--- a/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
@@ -1,5 +1,6 @@
 namespace ClickView.GoodStuff.Queues.RabbitMq.Internal;
 
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 using Serialization;
 
@@ -8,32 +9,52 @@ internal class RabbitMqCallbackConsumer<TData> : AsyncDefaultBasicConsumer
     private readonly SubscriptionContext _subscriptionContext;
     private readonly Func<MessageContext<TData>, CancellationToken, Task> _callback;
     private readonly IMessageSerializer _serializer;
+    private readonly ILogger<RabbitMqCallbackConsumer<TData>> _logger;
 
     public RabbitMqCallbackConsumer(SubscriptionContext subscriptionContext,
         Func<MessageContext<TData>, CancellationToken, Task> callback,
-        IMessageSerializer serializer)
+        IMessageSerializer serializer,
+        ILogger<RabbitMqCallbackConsumer<TData>> logger)
     {
         _subscriptionContext = subscriptionContext;
         _callback = callback;
         _serializer = serializer;
+        _logger = logger;
     }
 
-    public override async Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
+    public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
         string exchange, string routingKey, IBasicProperties properties, ReadOnlyMemory<byte> body)
     {
-        var message = _serializer.Deserialize<TData>(body.Span);
+        _logger.LogDebug(
+            "Queue message received. DeliveryTag: {DeliveryTag}, ConsumerTag: {ConsumerTag}, Exchange: {Exchange}, Redelivered: {Redelivered}",
+            deliveryTag, consumerTag, exchange, redelivered);
 
-        if (message is null)
-            throw new RabbitMqClientException("Failed to deserialize message");
+        return HandleBasicDeliverAsync(deliveryTag, body);
+    }
 
-        var context = new MessageContext<TData>(
-            data: message.Data,
-            deliveryTag: deliveryTag,
-            timestamp: DateTimeOffset.FromUnixTimeSeconds(message.Timestamp).UtcDateTime,
-            id: message.Id,
-            subscriptionContext: _subscriptionContext
-        );
+    private async Task HandleBasicDeliverAsync(ulong deliveryTag, ReadOnlyMemory<byte> body)
+    {
+        try
+        {
+            var message = _serializer.Deserialize<TData>(body.Span);
 
-        await _callback(context, CancellationToken.None);
+            if (message is null)
+                throw new RabbitMqClientException("Failed to deserialize message");
+
+            var context = new MessageContext<TData>(
+                data: message.Data,
+                deliveryTag: deliveryTag,
+                timestamp: DateTimeOffset.FromUnixTimeSeconds(message.Timestamp).UtcDateTime,
+                id: message.Id,
+                subscriptionContext: _subscriptionContext
+            );
+
+            await _callback(context, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception when processing queue message");
+            throw;
+        }
     }
 }

--- a/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
@@ -53,16 +53,19 @@ internal class RabbitMqCallbackConsumer<TData> : AsyncDefaultBasicConsumer
             );
 
             _taskWaiter.Increment();
-            await _callback(context, CancellationToken.None);
+            try
+            {
+                await _callback(context, CancellationToken.None);
+            }
+            finally
+            {
+                _taskWaiter.Decrement();
+            }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unhandled exception when processing queue message");
             throw;
-        }
-        finally
-        {
-            _taskWaiter.Decrement();
         }
     }
 }

--- a/src/Queues/RabbitMq/src/Internal/RabbitMqClientShims.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqClientShims.cs
@@ -1,0 +1,30 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Internal;
+
+using System.Reflection;
+using RabbitMQ.Client;
+
+internal static class RabbitMqClientShims
+{
+    public static Task CloseAsync(this IModel model)
+    {
+        var eventArgs = new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ReplySuccess,
+            "GoodBye");
+
+        return model.CloseAsync(eventArgs, false);
+    }
+
+    public static Task CloseAsync(this IModel model, ShutdownEventArgs reason, bool abort)
+    {
+        // Get the `_delegate` field
+        var delegateField = model.GetType().GetField("_delegate", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        // Get the value of that field
+        var recoveryAwareModel = delegateField!.GetValue(model);
+
+        // Get the close method with ShutdownEventArgs and bool as the args
+        var closeMethod = recoveryAwareModel!.GetType().GetMethod("Close", new[] { typeof(ShutdownEventArgs), typeof(bool) });
+
+        // Call that method
+        return (Task) closeMethod!.Invoke(recoveryAwareModel, new object[] { reason, abort })!;
+    }
+}

--- a/src/Queues/RabbitMq/src/MessageContext.cs
+++ b/src/Queues/RabbitMq/src/MessageContext.cs
@@ -20,13 +20,11 @@ public class MessageContext<TData>
 
     public Task AcknowledgeAsync()
     {
-        _subscriptionContext.AcknowledgeAsync(deliveryTag: DeliveryTag);
-        return Task.CompletedTask;
+        return _subscriptionContext.AcknowledgeAsync(deliveryTag: DeliveryTag);
     }
 
     public Task NegativeAcknowledgeAsync(bool requeue = true)
     {
-        _subscriptionContext.NegativeAcknowledgeAsync(deliveryTag: DeliveryTag, requeue: requeue);
-        return Task.CompletedTask;
+        return _subscriptionContext.NegativeAcknowledgeAsync(deliveryTag: DeliveryTag, requeue: requeue);
     }
 }

--- a/src/Queues/RabbitMq/src/MessageContext.cs
+++ b/src/Queues/RabbitMq/src/MessageContext.cs
@@ -1,0 +1,32 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public class MessageContext<TData>
+{
+    private readonly SubscriptionContext _subscriptionContext;
+
+    public MessageContext(TData data, ulong deliveryTag, DateTime timestamp, string id, SubscriptionContext subscriptionContext)
+    {
+        _subscriptionContext = subscriptionContext;
+        Data = data;
+        DeliveryTag = deliveryTag;
+        Timestamp = timestamp;
+        Id = id;
+    }
+
+    public TData Data { get; set; }
+    public ulong DeliveryTag { get; set; }
+    public DateTime Timestamp { get; set; }
+    public string Id { get; set; }
+
+    public Task AcknowledgeAsync()
+    {
+        _subscriptionContext.AcknowledgeAsync(deliveryTag: DeliveryTag);
+        return Task.CompletedTask;
+    }
+
+    public Task NegativeAcknowledgeAsync(bool requeue = true)
+    {
+        _subscriptionContext.NegativeAcknowledgeAsync(deliveryTag: DeliveryTag, requeue: requeue);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Queues/RabbitMq/src/MessageWrapper.cs
+++ b/src/Queues/RabbitMq/src/MessageWrapper.cs
@@ -2,14 +2,21 @@ namespace ClickView.GoodStuff.Queues.RabbitMq;
 
 public class MessageWrapper<TData>
 {
-    public required string Id { get; init; }
-    public required TData Data { get; init; }
-    public required long Timestamp { get; init; }
-
-    public static MessageWrapper<TData> Create(TData data) => new()
+    public MessageWrapper(string id, TData data, long timestamp)
     {
-        Id = Guid.NewGuid().ToString(),
-        Data = data,
-        Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-    };
+        Id = id;
+        Data = data;
+        Timestamp = timestamp;
+    }
+
+    public string Id { get; init; }
+    public TData Data { get; init; }
+    public long Timestamp { get; init; }
+
+    public static MessageWrapper<TData> New(TData data) => new
+    (
+        id: Guid.NewGuid().ToString(),
+        data: data,
+        timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+    );
 }

--- a/src/Queues/RabbitMq/src/MessageWrapper.cs
+++ b/src/Queues/RabbitMq/src/MessageWrapper.cs
@@ -1,0 +1,15 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public class MessageWrapper<TData>
+{
+    public required string Id { get; init; }
+    public required TData Data { get; init; }
+    public required long Timestamp { get; init; }
+
+    public static MessageWrapper<TData> Create(TData data) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        Data = data,
+        Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+    };
+}

--- a/src/Queues/RabbitMq/src/RabbitMqClient.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClient.cs
@@ -68,7 +68,8 @@ public class RabbitMqClient : IQueueClient
         // If no options are passed in, use the defaults
         options ??= SubscribeOptions.Default;
 
-        // Don't dispose channel, dispose the SubscriptionContext instead
+        // We don't want to dispose the channel here (unless an exception is thrown, see below).
+        // The returned SubscriptionContext is the object that should be disposed (which disposes the channel)
         var channel = await GetChannelAsync(cancellationToken);
 
         try
@@ -108,7 +109,7 @@ public class RabbitMqClient : IQueueClient
         }
         catch
         {
-            // on any exception, dispose the channel so we dont leak memory
+            // On any exception, dispose the channel so we dont leak memory
             channel.Dispose();
 
             throw;

--- a/src/Queues/RabbitMq/src/RabbitMqClient.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClient.cs
@@ -65,10 +65,19 @@ public class RabbitMqClient : IQueueClient, IAsyncDisposable
 
         try
         {
-            var subContext = new SubscriptionContext(channel, _activeSubscriptions);
+            var shutdownTaskWaiter = new CountWaiter();
+
+            var subContext = new SubscriptionContext(
+                queueName: queue,
+                channel: channel,
+                subscriptions: _activeSubscriptions,
+                taskWaiter: shutdownTaskWaiter,
+                logger: _options.LoggerFactory.CreateLogger<SubscriptionContext>());
+
             var consumer = new RabbitMqCallbackConsumer<TData>(
                 subContext,
                 callback,
+                shutdownTaskWaiter,
                 _options.Serializer,
                 _options.LoggerFactory.CreateLogger<RabbitMqCallbackConsumer<TData>>()
             );

--- a/src/Queues/RabbitMq/src/RabbitMqClient.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClient.cs
@@ -225,9 +225,14 @@ public class RabbitMqClient : IQueueClient, IAsyncDisposable
 
         // SSL
         factory.Ssl.Enabled = options.EnableSsl;
+        factory.Ssl.Version = options.SslVersion;
 
-        if (options.SslProtocols.HasValue)
-            factory.Ssl.Version = options.SslProtocols.Value;
+        if (options.IgnoreSslErrors)
+        {
+            factory.Ssl.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNotAvailable |
+                                                 SslPolicyErrors.RemoteCertificateChainErrors |
+                                                 SslPolicyErrors.RemoteCertificateNameMismatch;
+        }
 
         return factory;
     }

--- a/src/Queues/RabbitMq/src/RabbitMqClientException.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientException.cs
@@ -1,0 +1,8 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public class RabbitMqClientException : Exception
+{
+    public RabbitMqClientException(string message) : base(message)
+    {
+    }
+}

--- a/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
@@ -6,12 +6,14 @@ using Serialization;
 
 public class RabbitMqClientOptions : IOptions<RabbitMqClientOptions>
 {
-    public required string Host { get; set; }
+    public string Host { get; set; } = null!;
     public int Port { get; set; } = 5672;
     public string? Username { get; set; }
     public string? Password { get; set; }
     public TimeSpan? ConnectionTimeout { get; set; }
     public IMessageSerializer Serializer { get; set; } = NewtonsoftJsonMessageSerializer.Default;
+
+    public bool EnableSsl { get; set; }
     public SslProtocols? SslProtocols { get; set; }
 
     public RabbitMqClientOptions Value => this;

--- a/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
@@ -1,0 +1,18 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+using System.Security.Authentication;
+using Microsoft.Extensions.Options;
+using Serialization;
+
+public class RabbitMqClientOptions : IOptions<RabbitMqClientOptions>
+{
+    public required string Host { get; set; }
+    public int Port { get; set; } = 5672;
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public TimeSpan? ConnectionTimeout { get; set; }
+    public IMessageSerializer Serializer { get; set; } = NewtonsoftJsonMessageSerializer.Default;
+    public SslProtocols? SslProtocols { get; set; }
+
+    public RabbitMqClientOptions Value => this;
+}

--- a/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
@@ -8,14 +8,54 @@ using Serialization;
 
 public class RabbitMqClientOptions : IOptions<RabbitMqClientOptions>
 {
+    /// <summary>
+    /// The hostname of the RabbitMQ host
+    /// </summary>
     public string Host { get; set; } = null!;
+
+    /// <summary>
+    /// The port of the RabbitMQ instance
+    /// </summary>
     public int Port { get; set; } = 5672;
+
+    /// <summary>
+    /// Username for authenticating with RabbitMQ
+    /// </summary>
     public string? Username { get; set; }
+
+    /// <summary>
+    /// Password for authenticating with RabbitMQ
+    /// </summary>
     public string? Password { get; set; }
+
+    /// <summary>
+    /// Timeout for connection attempts
+    /// </summary>
     public TimeSpan? ConnectionTimeout { get; set; }
-    public IMessageSerializer Serializer { get; set; } = NewtonsoftJsonMessageSerializer.Default;
+
+    /// <summary>
+    /// Set to true to enable SSL
+    /// </summary>
     public bool EnableSsl { get; set; }
-    public SslProtocols? SslProtocols { get; set; }
+
+    /// <summary>
+    /// Set to false to ignore SSL errors
+    /// </summary>
+    public bool IgnoreSslErrors { get; set; }
+
+    /// <summary>
+    /// The TLS protocol version. Set to None to let the OS decide
+    /// </summary>
+    public SslProtocols SslVersion { get; set; } = SslProtocols.None;
+
+    /// <summary>
+    /// The serializer to use for serializing and deserializing messages
+    /// </summary>
+    public IMessageSerializer Serializer { get; set; } = NewtonsoftJsonMessageSerializer.Default;
+
+    /// <summary>
+    /// The logger factory to enable logging
+    /// </summary>
     public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
 
     public RabbitMqClientOptions Value => this;

--- a/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
@@ -1,6 +1,8 @@
 namespace ClickView.GoodStuff.Queues.RabbitMq;
 
 using System.Security.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Serialization;
 
@@ -12,9 +14,9 @@ public class RabbitMqClientOptions : IOptions<RabbitMqClientOptions>
     public string? Password { get; set; }
     public TimeSpan? ConnectionTimeout { get; set; }
     public IMessageSerializer Serializer { get; set; } = NewtonsoftJsonMessageSerializer.Default;
-
     public bool EnableSsl { get; set; }
     public SslProtocols? SslProtocols { get; set; }
+    public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
 
     public RabbitMqClientOptions Value => this;
 }

--- a/src/Queues/RabbitMq/src/Serialization/IMessageSerializer.cs
+++ b/src/Queues/RabbitMq/src/Serialization/IMessageSerializer.cs
@@ -1,0 +1,7 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Serialization;
+
+public interface IMessageSerializer
+{
+    public ReadOnlyMemory<byte> Serialize<TData>(MessageWrapper<TData> message);
+    public MessageWrapper<TData>? Deserialize<TData>(ReadOnlySpan<byte> bytes);
+}

--- a/src/Queues/RabbitMq/src/Serialization/NewtonsoftJsonMessageSerializer.cs
+++ b/src/Queues/RabbitMq/src/Serialization/NewtonsoftJsonMessageSerializer.cs
@@ -1,0 +1,37 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Serialization;
+
+using System.Text;
+using Newtonsoft.Json;
+
+public class NewtonsoftJsonMessageSerializer : IMessageSerializer
+{
+    private readonly JsonSerializerSettings _settings;
+
+    public NewtonsoftJsonMessageSerializer() :this(GetDefaultSettings())
+    {
+    }
+
+    public NewtonsoftJsonMessageSerializer(JsonSerializerSettings settings)
+    {
+        _settings = settings;
+    }
+
+    public static NewtonsoftJsonMessageSerializer Default = new();
+
+    private static JsonSerializerSettings GetDefaultSettings()
+    {
+        return new JsonSerializerSettings();
+    }
+
+    public ReadOnlyMemory<byte> Serialize<TData>(MessageWrapper<TData> message)
+    {
+        var json = JsonConvert.SerializeObject(message, _settings);
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    public MessageWrapper<TData>? Deserialize<TData>(ReadOnlySpan<byte> bytes)
+    {
+        var json = Encoding.UTF8.GetString(bytes);
+        return JsonConvert.DeserializeObject<MessageWrapper<TData>>(json, _settings);
+    }
+}

--- a/src/Queues/RabbitMq/src/Serialization/SystemTextJsonMessageSerializer.cs
+++ b/src/Queues/RabbitMq/src/Serialization/SystemTextJsonMessageSerializer.cs
@@ -1,0 +1,37 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq.Serialization;
+
+using System.Text.Json;
+
+public class SystemTextJsonMessageSerializer : IMessageSerializer
+{
+    private readonly JsonSerializerOptions _options;
+
+    public SystemTextJsonMessageSerializer() : this(GetDefaultOptions())
+    {
+    }
+
+    public SystemTextJsonMessageSerializer(JsonSerializerOptions options)
+    {
+        _options = options;
+    }
+
+    public static SystemTextJsonMessageSerializer Default = new();
+
+    private static JsonSerializerOptions GetDefaultOptions()
+    {
+        return new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public ReadOnlyMemory<byte> Serialize<TData>(MessageWrapper<TData> message)
+    {
+        return JsonSerializer.SerializeToUtf8Bytes(message, _options);
+    }
+
+    public MessageWrapper<TData>? Deserialize<TData>(ReadOnlySpan<byte> bytes)
+    {
+        return JsonSerializer.Deserialize<MessageWrapper<TData>>(bytes, _options);
+    }
+}

--- a/src/Queues/RabbitMq/src/SubscribeOptions.cs
+++ b/src/Queues/RabbitMq/src/SubscribeOptions.cs
@@ -1,0 +1,9 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public class SubscribeOptions
+{
+    public bool AutoAcknowledge { get; set; }
+    public ushort PrefetchCount { get; set; } = 1;
+
+    internal static readonly SubscribeOptions Default = new();
+}

--- a/src/Queues/RabbitMq/src/SubscribeOptions.cs
+++ b/src/Queues/RabbitMq/src/SubscribeOptions.cs
@@ -2,8 +2,8 @@ namespace ClickView.GoodStuff.Queues.RabbitMq;
 
 public class SubscribeOptions
 {
-    public bool AutoAcknowledge { get; set; }
-    public ushort PrefetchCount { get; set; } = 1;
+    public bool AutoAcknowledge { get; init; }
+    public ushort PrefetchCount { get; init; } = 1;
 
     internal static readonly SubscribeOptions Default = new();
 }

--- a/src/Queues/RabbitMq/src/SubscriptionContext.cs
+++ b/src/Queues/RabbitMq/src/SubscriptionContext.cs
@@ -1,0 +1,59 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+using Internal;
+using RabbitMQ.Client;
+
+public class SubscriptionContext : IAsyncDisposable
+{
+    private readonly IModel _channel;
+    private readonly ActiveSubscriptions _subscriptions;
+    private string? _consumerTag;
+    private bool _disposed;
+
+    internal SubscriptionContext(IModel channel, ActiveSubscriptions subscriptions)
+    {
+        _channel = channel;
+        _subscriptions = subscriptions;
+    }
+
+    internal void SetConsumerTag(string consumerTag) => _consumerTag = consumerTag;
+
+    public Task AcknowledgeAsync(ulong deliveryTag, bool multiple = false)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _channel.BasicAck(
+            deliveryTag: deliveryTag,
+            multiple: multiple);
+
+        return Task.CompletedTask;
+    }
+
+    public Task NegativeAcknowledgeAsync(ulong deliveryTag, bool multiple = false, bool requeue = true)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        _channel.BasicNack(
+            deliveryTag: deliveryTag,
+            multiple: multiple,
+            requeue: requeue);
+
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return ValueTask.CompletedTask;
+
+        _disposed = true;
+
+        _channel.BasicCancel(_consumerTag);
+        _channel.Close();
+        _channel.Dispose();
+
+        _subscriptions.Remove(this);
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Queues/RabbitMq/src/SubscriptionContext.cs
+++ b/src/Queues/RabbitMq/src/SubscriptionContext.cs
@@ -1,19 +1,31 @@
 namespace ClickView.GoodStuff.Queues.RabbitMq;
 
 using Internal;
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
 public class SubscriptionContext : IAsyncDisposable
 {
+    private readonly string _queueName;
     private readonly IModel _channel;
     private readonly ActiveSubscriptions _subscriptions;
+    private readonly CountWaiter _taskWaiter;
+    private readonly ILogger<SubscriptionContext> _logger;
     private string? _consumerTag;
     private bool _disposed;
 
-    internal SubscriptionContext(IModel channel, ActiveSubscriptions subscriptions)
+    internal SubscriptionContext(
+        string queueName,
+        IModel channel,
+        ActiveSubscriptions subscriptions,
+        CountWaiter taskWaiter,
+        ILogger<SubscriptionContext> logger)
     {
+        _queueName = queueName;
         _channel = channel;
         _subscriptions = subscriptions;
+        _taskWaiter = taskWaiter;
+        _logger = logger;
     }
 
     internal void SetConsumerTag(string consumerTag) => _consumerTag = consumerTag;
@@ -21,6 +33,8 @@ public class SubscriptionContext : IAsyncDisposable
     public Task AcknowledgeAsync(ulong deliveryTag, bool multiple = false)
     {
         CheckDisposed();
+
+        _logger.LogDebug("Sending ack {DeliveryTag}", deliveryTag);
 
         _channel.BasicAck(
             deliveryTag: deliveryTag,
@@ -33,6 +47,8 @@ public class SubscriptionContext : IAsyncDisposable
     {
         CheckDisposed();
 
+        _logger.LogDebug("Sending nack {DeliveryTag}", deliveryTag);
+
         _channel.BasicNack(
             deliveryTag: deliveryTag,
             multiple: multiple,
@@ -41,21 +57,33 @@ public class SubscriptionContext : IAsyncDisposable
         return Task.CompletedTask;
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (_disposed)
-            return ValueTask.CompletedTask;
+            return;
 
-        // Cancel first
+        _logger.LogDebug("Disposing subscription context...");
+
+        // Unsubscribe from the queue to stop receiving any new messages
+        _logger.LogDebug("Unsubscribing from queue {QueueName}", _queueName);
         _channel.BasicCancel(_consumerTag);
-        _channel.Close();
 
+        // Wait for all tasks to complete before closing the connection
+        // If we close the connection first then the tasks cant ack
+        _logger.LogDebug("Waiting for all tasks to finish...");
+        await _taskWaiter.WaitAsync();
+
+        // Close the channel
+        _logger.LogDebug("Closing channel");
+        await _channel.CloseAsync();
+
+        // Dispose
         _disposed = true;
         _channel.Dispose();
 
         _subscriptions.Remove(this);
 
-        return ValueTask.CompletedTask;
+        _logger.LogDebug("Subscription context disposed");
     }
 
     private void CheckDisposed()


### PR DESCRIPTION
Added a basic rabbitmq client wrapper

Main changes over the previous client:
- Connection to RabbitMQ is no longer done in the constructor and instead done when trying to access RabbitMQ
- Can change the serializer via `IMessageSerializer`
- Added debug logging
- Can (or should?) subscribe to multiple queues (not tested)
- Subscribe gives the callback a message context which contains:
  - Id and Timestamp of the message
  - Ack and Nack methods for easier acknowledgement 
- Removed most methods to simplify interface

Other changes:
- Reduce number of lambdas to reduce memory allocations
- Added `SystemTextJson` message serializer (`Newtonsoft.Json` is the default to be non breaking)
- Use `DispatchConsumersAsync` and `AsyncDefaultBasicConsumer` for better async support

It should also be very easy to update this to the new RabbitMQ 7.x client once thats ready