### PR TITLE
Batch hosted queue

### DIFF
--- a/src/Hosting/Queue/src/BaseQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BaseQueueHostedService.cs
@@ -21,12 +21,12 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
     /// <summary>
     /// Gets the <see cref="ILogger"/>.
     /// </summary>
-    protected readonly ILogger Logger;
+    protected ILogger Logger { get; }
 
     /// <summary>
     /// Gets the options.
     /// </summary>
-    protected readonly TOptions Options;
+    protected TOptions Options { get; }
 
     /// <summary>
     /// Initialises a new instance of <see cref="BaseQueueHostedService{TOptions}"/>.
@@ -90,11 +90,15 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
         {
             var subContext = _subscriptionContext;
 
+            // Dispose the subscription context to unsubscribe from the queue
             if (subContext is not null)
             {
                 await subContext.DisposeAsync();
                 _subscriptionContext = null;
             }
+
+            // Call any other code we need to do on stop after the subscription is closed
+            await OnStopAsync(cancellationToken);
         }
         finally
         {
@@ -106,6 +110,16 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore();
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes the current <see cref="BaseQueueHostedService{TOptions}"/> instance
+    /// </summary>
+    protected virtual async ValueTask DisposeAsyncCore()
     {
         if (_disposed)
             return;
@@ -132,6 +146,35 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
     /// <returns></returns>
     protected abstract Task<SubscriptionContext> SubscribeAsync(IQueueClient queueClient, string queueName,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Called when the queue service is stopping and the subscription has been unsubscribed
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected virtual Task OnStopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Acknowledges one or more messages
+    /// </summary>
+    /// <param name="deliveryTag">The delivery tag of the message to acknowledge</param>
+    /// <param name="multiple">If true, acknowledge all outstanding delivery tags up to and including the delivery tag</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected Task AcknowledgeAsync(ulong deliveryTag, bool multiple = false, CancellationToken cancellationToken = default)
+    {
+        CheckDisposed();
+
+        var subContext = _subscriptionContext;
+        if (subContext is null)
+            throw new InvalidOperationException("Cannot call acknowledge before starting the worker");
+
+        if (subContext.IsOpen)
+            return subContext.AcknowledgeAsync(deliveryTag, multiple, cancellationToken);
+
+        Logger.LogWarning("Cannot acknowledge task. Channel is not open");
+        return Task.CompletedTask;
+    }
 
     private static RabbitMqClientOptions CreateOptions(BaseQueueHostedServiceOptions options, ILoggerFactory loggerFactory)
     {

--- a/src/Hosting/Queue/src/BaseQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BaseQueueHostedService.cs
@@ -1,0 +1,169 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Queues.RabbitMq;
+
+/// <summary>
+/// A base class for all queue hosted services to inherit from
+/// </summary>
+/// <typeparam name="TOptions"></typeparam>
+public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncDisposable
+    where TOptions : BaseQueueHostedServiceOptions
+{
+    private readonly SemaphoreSlim _subscriptionLock = new(1, 1);
+    private readonly IQueueClient _queueClient;
+    private readonly string _name;
+    private SubscriptionContext? _subscriptionContext;
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets the <see cref="ILogger"/>.
+    /// </summary>
+    protected readonly ILogger Logger;
+
+    /// <summary>
+    /// Gets the options.
+    /// </summary>
+    protected readonly TOptions Options;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="BaseQueueHostedService{TOptions}"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="loggerFactory"></param>
+    protected BaseQueueHostedService(IOptions<TOptions> options, ILoggerFactory loggerFactory)
+    {
+        var type = GetType();
+
+        _name = type.Name;
+        Options = options.Value;
+        Logger = loggerFactory.CreateLogger(type);
+
+        _queueClient = new RabbitMqClient(CreateOptions(Options, loggerFactory));
+    }
+
+    /// <summary>
+    /// Triggered when the application host is ready to start the service.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        CheckDisposed();
+
+        await _subscriptionLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            // If we have a context, don't start again
+            if (_subscriptionContext is not null)
+                throw new InvalidOperationException($"Cannot start already started service {_name} ");
+
+            var queueName = Options.QueueName;
+
+            if (string.IsNullOrWhiteSpace(queueName))
+                throw new ArgumentException($"{nameof(QueueHostedServiceOptions.QueueName)} is required");
+
+            _subscriptionContext = await SubscribeAsync(_queueClient, queueName, cancellationToken);
+        }
+        finally
+        {
+            _subscriptionLock.Release();
+        }
+
+        Logger.LogInformation("Queue service started - {Name}", _name);
+    }
+
+    /// <summary>
+    /// Triggered when the application host is performing a graceful shutdown.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        CheckDisposed();
+
+        await _subscriptionLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            var subContext = _subscriptionContext;
+
+            if (subContext is not null)
+            {
+                await subContext.DisposeAsync();
+                _subscriptionContext = null;
+            }
+        }
+        finally
+        {
+            _subscriptionLock.Release();
+        }
+
+        Logger.LogInformation("Queue service stopped - {Name}", _name);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        // If we still have an open subscription, Dispose it
+        if (_subscriptionContext != null)
+            await _subscriptionContext.DisposeAsync();
+
+        // Then finally dispose the client
+        await _queueClient.DisposeAsync();
+
+        // Clean up everything else
+        _subscriptionLock.Dispose();
+    }
+
+    /// <summary>
+    /// Creates a subscription context
+    /// </summary>
+    /// <param name="queueClient"></param>
+    /// <param name="queueName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected abstract Task<SubscriptionContext> SubscribeAsync(IQueueClient queueClient, string queueName,
+        CancellationToken cancellationToken);
+
+    private static RabbitMqClientOptions CreateOptions(BaseQueueHostedServiceOptions options, ILoggerFactory loggerFactory)
+    {
+        var host = options.Host;
+
+        if (string.IsNullOrWhiteSpace(host))
+            throw new ArgumentException($"{nameof(QueueHostedServiceOptions.Host)} is required");
+
+        var o = new RabbitMqClientOptions
+        {
+            Host = host,
+            Port = options.Port,
+            Username = options.Username,
+            Password = options.Password,
+            ConnectionTimeout = options.ConnectionTimeout,
+            EnableSsl = options.EnableSsl,
+            IgnoreSslErrors = options.IgnoreSslErrors,
+            LoggerFactory = loggerFactory
+        };
+
+        if (options.SslVersion != null)
+            o.SslVersion = options.SslVersion.Value;
+
+        if (options.Serializer != null)
+            o.Serializer = options.Serializer;
+
+        return o;
+    }
+
+    private void CheckDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
+    }
+}

--- a/src/Hosting/Queue/src/BaseQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BaseQueueHostedService.cs
@@ -72,7 +72,7 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
             _subscriptionLock.Release();
         }
 
-        Logger.LogInformation("Queue service started - {Name}", _name);
+        Logger.QueueServiceStarted(_name);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
             _subscriptionLock.Release();
         }
 
-        Logger.LogInformation("Queue service stopped - {Name}", _name);
+        Logger.QueueServiceStopped(_name);
     }
 
     /// <inheritdoc />
@@ -172,7 +172,7 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
         if (subContext.IsOpen)
             return subContext.AcknowledgeAsync(deliveryTag, multiple, cancellationToken);
 
-        Logger.LogWarning("Cannot acknowledge task. Channel is not open");
+        Logger.AcknowledgeFailureChannelNotOpen(deliveryTag);
         return Task.CompletedTask;
     }
 

--- a/src/Hosting/Queue/src/BaseQueueHostedServiceOptions.cs
+++ b/src/Hosting/Queue/src/BaseQueueHostedServiceOptions.cs
@@ -1,0 +1,60 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+using System.Security.Authentication;
+using Queues.RabbitMq.Serialization;
+
+/// <summary>
+/// Base queue options which is shared amongst the various hosted queue workers
+/// </summary>
+public abstract class BaseQueueHostedServiceOptions
+{
+    /// <summary>
+    /// The name of the queue to subscribe to.
+    /// </summary>
+    public string? QueueName { get; set; }
+
+    /// <summary>
+    /// The hostname or network address of the queue server in which to connect.
+    /// </summary>
+    public string? Host { get; set; }
+
+    /// <summary>
+    /// The port that the queue server is listening to.
+    /// </summary>
+    public ushort Port { get; set; } = 5672;
+
+    /// <summary>
+    /// The username of the user for the queue.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// The password of the user for the queue.
+    /// </summary>
+    public string? Password { get; set; }
+
+    /// <summary>
+    /// Timeout for connection attempts
+    /// </summary>
+    public TimeSpan? ConnectionTimeout { get; set; }
+
+    /// <summary>
+    /// Set to true to enable SSL
+    /// </summary>
+    public bool EnableSsl { get; set; }
+
+    /// <summary>
+    /// Set to false to ignore SSL errors
+    /// </summary>
+    public bool IgnoreSslErrors { get; set; }
+
+    /// <summary>
+    /// The TLS protocol version. Set to None to let the OS decide
+    /// </summary>
+    public SslProtocols? SslVersion { get; set; }
+
+    /// <summary>
+    /// The serializer to use for deserializing messages from the Queue
+    /// </summary>
+    public IMessageSerializer? Serializer { get; set; }
+}

--- a/src/Hosting/Queue/src/BatchQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BatchQueueHostedService.cs
@@ -168,6 +168,10 @@ public abstract class BatchQueueHostedService<TMessage, TOptions> : BaseQueueHos
                     if (_currentBuffer.Count == 0)
                     {
                         snapshotBuffer = false;
+
+                        // We set the last process to now when we have nothing in the buffer
+                        // This is to prevent the MaxFlush check to trigger when we receive a message after a long time
+                        _lastProcess = now;
                     }
                     else
                     {

--- a/src/Hosting/Queue/src/BatchQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BatchQueueHostedService.cs
@@ -1,0 +1,267 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Queues.RabbitMq;
+
+public abstract class BatchQueueHostedService<TMessage, TOptions> : BaseQueueHostedService<TOptions>
+    where TOptions : BatchQueueHostedServiceOptions
+{
+    // Flush interval
+    private Task? _workerTask;
+    private CancellationTokenSource? _cts;
+
+    // Buffer processing
+    private readonly List<TMessage> _currentBuffer;
+    private readonly object _bufferLock = new();
+    private readonly SemaphoreSlim _workerLock = new(1, 1);
+    private ulong _lastDeliveryTag;
+    private DateTime _lastMessage = DateTime.MinValue;
+    private DateTime _lastProcess = DateTime.UtcNow;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="QueueHostedService{TMessage,TOptions}"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="loggerFactory"></param>
+    protected BatchQueueHostedService(IOptions<TOptions> options, ILoggerFactory loggerFactory) : base(options, loggerFactory)
+    {
+        _currentBuffer = new List<TMessage>(Options.BatchSize);
+    }
+
+    /// <inheritdoc />
+    protected override async Task<SubscriptionContext> SubscribeAsync(IQueueClient queueClient, string queueName, CancellationToken cancellationToken)
+    {
+        // Validate options
+        var minFlushInterval = Options.MinFlushInterval;
+        var maxFlushInterval = Options.MaxFlushInterval;
+
+        if (maxFlushInterval < minFlushInterval)
+            throw new Exception(
+                $"{nameof(Options.MaxFlushInterval)} must be greater than {nameof(Options.MinFlushInterval)}");
+
+        var subscriptionContext = await queueClient.SubscribeAsync<TMessage>(queueName, OnMessageAsync,
+            new SubscribeOptions
+            {
+                PrefetchCount = Options.BatchSize,
+                AutoAcknowledge = false
+            }, cancellationToken);
+
+        // Start background worker task if we have a minimum or a maximum flush interval
+        if (minFlushInterval > TimeSpan.Zero || maxFlushInterval > TimeSpan.Zero)
+        {
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _workerTask = IntervalWorkerAsync(_cts.Token);
+        }
+
+        return subscriptionContext;
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnStopAsync(CancellationToken cancellationToken)
+    {
+        // Stop the worker task and wait for it to finish if it exists
+        _cts?.Cancel();
+        var workerTask = _workerTask;
+        if (workerTask is not null)
+        {
+            try
+            {
+                await workerTask;
+            }
+            catch (OperationCanceledException) when (_cts!.IsCancellationRequested)
+            {
+                // ignore the cancelled task exception when it was us that cancelled the task
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async ValueTask DisposeAsyncCore()
+    {
+         await base.DisposeAsyncCore();
+
+         _cts?.Dispose();
+         _workerLock.Dispose();
+         _workerTask = null;
+    }
+
+    /// <summary>
+    /// This method is called when a batch of messages have been received from the configured queue.
+    /// </summary>
+    /// <param name="messages"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected abstract Task OnMessagesAsync(IEnumerable<TMessage> messages,
+        CancellationToken cancellationToken = default);
+
+    private async Task OnMessageAsync(MessageContext<TMessage> context, CancellationToken cancellationToken)
+    {
+        Logger.LogDebug("Queue message received");
+
+        List<TMessage> snapshot;
+
+        lock (_bufferLock)
+        {
+            // Update last message time
+            _lastMessage = Now();
+
+            // Add message into buffer
+            _currentBuffer.Add(context.Data);
+            _lastDeliveryTag = context.DeliveryTag;
+
+            // If our buffer is at max size then we need to process the items
+            if (_currentBuffer.Count < Options.BatchSize)
+                return;
+
+            snapshot = _currentBuffer.ToList();
+            _currentBuffer.Clear();
+            _lastDeliveryTag = 0;
+        }
+
+        Logger.LogDebug("Message buffer {MessageBufferSize} limit reached. Processing items...", Options.BatchSize);
+
+        await ProcessItemsAsync(snapshot, context.DeliveryTag, cancellationToken);
+    }
+
+    /// <summary>
+    /// Task which loops on an interval to check if we need to process an items
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    private async Task IntervalWorkerAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                var now = Now();
+                var minFlushInterval = Options.MinFlushInterval;
+                var maxFlushInterval = Options.MaxFlushInterval;
+
+                var timeSinceLastMessage = now - _lastMessage;
+                var timeSinceLastProcess = now - _lastProcess;
+
+                // First check to make sure that we haven't waited over our maximum allowed time since last process
+                if (maxFlushInterval > TimeSpan.Zero && timeSinceLastProcess > maxFlushInterval)
+                {
+                    Logger.LogDebug("Last process was {TimeSinceLastProcess} ago. Forcing processing...",
+                        timeSinceLastProcess);
+                }
+                // Check if we received a message recently and if we have then wait until the next interval
+                else if (minFlushInterval > TimeSpan.Zero && timeSinceLastMessage < minFlushInterval)
+                {
+                    var waitTime = minFlushInterval - timeSinceLastMessage;
+
+                    // Because Task.Delay is not accurate and may wait shorter than required,
+                    // we'll add an extra second to the wait time to prevent spamming
+                    waitTime += TimeSpan.FromSeconds(1);
+
+                    Logger.LogDebug("Last message received {TimeSinceLastMessage} ago. Waiting {WaitTime} to flush...",
+                        timeSinceLastMessage, waitTime);
+
+                    await Task.Delay(waitTime, cancellationToken);
+
+                    continue;
+                }
+
+                // We may need to process the items
+                // Lets check the message size and if we have any items then process
+
+                ulong latestDeliveryTag;
+                IReadOnlyCollection<TMessage> snapshot;
+
+                lock (_bufferLock)
+                {
+                    // Nothing in the buffer, therefore nothing to do
+                    if (_currentBuffer.Count == 0)
+                    {
+                        snapshot = Array.Empty<TMessage>();
+                        latestDeliveryTag = 0;
+                    }
+                    else
+                    {
+                        // Take a copy of the buffer and reset
+                        snapshot = _currentBuffer.ToList();
+                        latestDeliveryTag = _lastDeliveryTag;
+                        _currentBuffer.Clear();
+                        _lastDeliveryTag = 0;
+                    }
+                }
+
+                // Same check exists in ProcessItemsAsync but im doing it here as well to avoid the await overhead
+                // if we have 0 items
+                if (snapshot.Count > 0)
+                {
+                    await ProcessItemsAsync(snapshot, latestDeliveryTag, cancellationToken);
+                }
+                else
+                {
+                    _lastProcess = Now();
+                }
+
+                Logger.LogDebug("Waiting {FlushInterval} until next flush interval", minFlushInterval);
+                await Task.Delay(minFlushInterval, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Propagate up to caller to handle
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Unexpected exception thrown when running interval check");
+
+                // Wait before trying again
+                await Task.Delay(Options.MinFlushInterval, cancellationToken);
+            }
+        }
+    }
+
+    private async Task ProcessItemsAsync(IReadOnlyCollection<TMessage> messages,
+        ulong latestDeliveryTag,
+        CancellationToken cancellationToken)
+    {
+        if (messages.Count == 0)
+        {
+            // If there's noting to process, update the process time anyway
+            // We do this because if we've not received any items it will have a last process time
+            // in the past which will force the first check to always process whatever is in the buffer
+            _lastProcess = Now();
+            return;
+        }
+
+        await _workerLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            Logger.LogInformation("Processing {Count} items", messages.Count);
+
+            await OnMessagesAsync(messages, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Propagate up to caller to handle
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unhandled exception caught when processing message");
+        }
+        finally
+        {
+            // Finally, acknowledge the message
+            // Another try here to make sure we release the workerLock if anything goes wrong when acknowledging
+            try
+            {
+                await AcknowledgeAsync(latestDeliveryTag, true, cancellationToken);
+            }
+            finally
+            {
+                _lastProcess = Now();
+                _workerLock.Release();
+            }
+        }
+    }
+
+    private static DateTime Now() => DateTime.UtcNow;
+}

--- a/src/Hosting/Queue/src/BatchQueueHostedServiceOptions.cs
+++ b/src/Hosting/Queue/src/BatchQueueHostedServiceOptions.cs
@@ -10,7 +10,16 @@ public abstract class BatchQueueHostedServiceOptions : BaseQueueHostedServiceOpt
     /// </summary>
     public ushort BatchSize { get; set; } = 100;
 
+    /// <summary>
+    /// The minimum time between messages that processing will occur.
+    ///
+    /// For example, if this value is set to 5 seconds and only one message is received,
+    /// then after 5 seconds of receiving the message the batch process will run.
+    /// </summary>
     public TimeSpan MinFlushInterval { get; set; } = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// The maximum time a message can sit in the buffer before being processed.
+    /// </summary>
     public TimeSpan MaxFlushInterval { get; set; } = TimeSpan.FromMinutes(1);
 }

--- a/src/Hosting/Queue/src/BatchQueueHostedServiceOptions.cs
+++ b/src/Hosting/Queue/src/BatchQueueHostedServiceOptions.cs
@@ -1,0 +1,16 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+/// <summary>
+/// Options for the <see cref="QueueHostedService{TMessage,TOptions}"/>
+/// </summary>
+public abstract class BatchQueueHostedServiceOptions : BaseQueueHostedServiceOptions
+{
+    /// <summary>
+    /// The number of tasks to run concurrently.
+    /// </summary>
+    public ushort BatchSize { get; set; } = 100;
+
+    public TimeSpan MinFlushInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    public TimeSpan MaxFlushInterval { get; set; } = TimeSpan.FromMinutes(1);
+}

--- a/src/Hosting/Queue/src/FlushReason.cs
+++ b/src/Hosting/Queue/src/FlushReason.cs
@@ -1,0 +1,8 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+internal enum FlushReason
+{
+    MaxIntervalReached,
+    IntervalReached,
+    BufferFull
+}

--- a/src/Hosting/Queue/src/LoggerExtensions.cs
+++ b/src/Hosting/Queue/src/LoggerExtensions.cs
@@ -16,13 +16,13 @@ internal static partial class LoggerExtensions
     [LoggerMessage(4, LogLevel.Warning, "Cannot acknowledge task {DeliveryTag}. Channel is not open")]
     public static partial void AcknowledgeFailureChannelNotOpen(this ILogger logger, ulong deliveryTag);
 
-    [LoggerMessage(5, LogLevel.Information, "Message buffer limit reached ({MessageBufferSize}). Processing items")]
+    [LoggerMessage(5, LogLevel.Information, "Message buffer limit reached ({MessageBufferSize})")]
     public static partial void BatchProcessMessageBufferReached(this ILogger logger, ushort messageBufferSize);
 
-    [LoggerMessage(6, LogLevel.Information, "Last process occured at {LastProcessTime}. Processing items")]
+    [LoggerMessage(6, LogLevel.Information, "Last process occured at {LastProcessTime}")]
     public static partial void BatchProcessIntervalReached(this ILogger logger, DateTime lastProcessTime);
 
-    [LoggerMessage(7, LogLevel.Debug, "Max flush interval reached ({TimeSinceLastProcess})")]
+    [LoggerMessage(7, LogLevel.Information, "Max flush interval reached ({TimeSinceLastProcess})")]
     public static partial void BatchProcessMaxFlushIntervalReached(this ILogger logger, TimeSpan timeSinceLastProcess);
 
     [LoggerMessage(8, LogLevel.Debug, "Last message received {TimeSinceLastMessage} ago. Waiting {WaitTime} until next flush interval")]

--- a/src/Hosting/Queue/src/LoggerExtensions.cs
+++ b/src/Hosting/Queue/src/LoggerExtensions.cs
@@ -1,0 +1,46 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+using Microsoft.Extensions.Logging;
+
+internal static partial class LoggerExtensions
+{
+    [LoggerMessage(1, LogLevel.Information, "Queue service started - {Name}", EventName = "QueueServiceStarted")]
+    public static partial void QueueServiceStarted(this ILogger logger, string name);
+
+    [LoggerMessage(2, LogLevel.Information, "Queue service stopped - {Name}", EventName = "QueueServiceStopped")]
+    public static partial void QueueServiceStopped(this ILogger logger, string name);
+
+    [LoggerMessage(3, LogLevel.Debug, "Queue message received", EventName = "QueueMessageReceived")]
+    public static partial void QueueMessageReceived(this ILogger logger);
+
+    [LoggerMessage(4, LogLevel.Warning, "Cannot acknowledge task {DeliveryTag}. Channel is not open",
+        EventName = "AcknowledgeFailureChannelNotOpen")]
+    public static partial void AcknowledgeFailureChannelNotOpen(this ILogger logger, ulong deliveryTag);
+
+    [LoggerMessage(5, LogLevel.Information, "Message buffer limit reached ({MessageBufferSize}). Processing items",
+        EventName = "BatchProcessMessageBufferReached")]
+    public static partial void BatchProcessMessageBufferReached(this ILogger logger, ushort messageBufferSize);
+
+    [LoggerMessage(6, LogLevel.Information, "Last process occured at {LastProcessTime}. Processing items",
+        EventName = "BatchProcessIntervalReached")]
+    public static partial void BatchProcessIntervalReached(this ILogger logger, DateTime lastProcessTime);
+
+    [LoggerMessage(7, LogLevel.Debug, "Max flush interval reached ({TimeSinceLastProcess})",
+        EventName = "BatchProcessMaxFlushIntervalReached")]
+    public static partial void BatchProcessMaxFlushIntervalReached(this ILogger logger, TimeSpan timeSinceLastProcess);
+
+    [LoggerMessage(8, LogLevel.Debug, "Last message received {TimeSinceLastMessage} ago. Waiting {WaitTime} until next flush interval",
+        EventName = "BatchProcessMinFlushIntervalNotReached")]
+    public static partial void BatchProcessMinFlushIntervalNotReached(this ILogger logger, TimeSpan timeSinceLastMessage, TimeSpan waitTime);
+
+    [LoggerMessage(9, LogLevel.Debug, "Waiting {WaitTime} until next flush interval",
+        EventName = "BatchProcessIntervalWait")]
+    public static partial void BatchProcessIntervalWait(this ILogger logger, TimeSpan waitTime);
+
+    [LoggerMessage(10, LogLevel.Information, "Processing {Count} items...", EventName = "BatchProcessStart")]
+    public static partial void BatchProcessStart(this ILogger logger, int count);
+
+    [LoggerMessage(11, LogLevel.Information, "Processed {Count} items in {ProcessDuration}",
+        EventName = "BatchProcessCompleted")]
+    public static partial void BatchProcessCompleted(this ILogger logger, int count, TimeSpan processDuration);
+}

--- a/src/Hosting/Queue/src/LoggerExtensions.cs
+++ b/src/Hosting/Queue/src/LoggerExtensions.cs
@@ -4,43 +4,36 @@ using Microsoft.Extensions.Logging;
 
 internal static partial class LoggerExtensions
 {
-    [LoggerMessage(1, LogLevel.Information, "Queue service started - {Name}", EventName = "QueueServiceStarted")]
+    [LoggerMessage(1, LogLevel.Information, "Queue service started - {Name}")]
     public static partial void QueueServiceStarted(this ILogger logger, string name);
 
-    [LoggerMessage(2, LogLevel.Information, "Queue service stopped - {Name}", EventName = "QueueServiceStopped")]
+    [LoggerMessage(2, LogLevel.Information, "Queue service stopped - {Name}")]
     public static partial void QueueServiceStopped(this ILogger logger, string name);
 
-    [LoggerMessage(3, LogLevel.Debug, "Queue message received", EventName = "QueueMessageReceived")]
-    public static partial void QueueMessageReceived(this ILogger logger);
+    [LoggerMessage(3, LogLevel.Debug, "Queue message received (Id: {Id}, Timestamp: {Timestamp})")]
+    public static partial void QueueMessageReceived(this ILogger logger, string id, DateTime timestamp);
 
-    [LoggerMessage(4, LogLevel.Warning, "Cannot acknowledge task {DeliveryTag}. Channel is not open",
-        EventName = "AcknowledgeFailureChannelNotOpen")]
+    [LoggerMessage(4, LogLevel.Warning, "Cannot acknowledge task {DeliveryTag}. Channel is not open")]
     public static partial void AcknowledgeFailureChannelNotOpen(this ILogger logger, ulong deliveryTag);
 
-    [LoggerMessage(5, LogLevel.Information, "Message buffer limit reached ({MessageBufferSize}). Processing items",
-        EventName = "BatchProcessMessageBufferReached")]
+    [LoggerMessage(5, LogLevel.Information, "Message buffer limit reached ({MessageBufferSize}). Processing items")]
     public static partial void BatchProcessMessageBufferReached(this ILogger logger, ushort messageBufferSize);
 
-    [LoggerMessage(6, LogLevel.Information, "Last process occured at {LastProcessTime}. Processing items",
-        EventName = "BatchProcessIntervalReached")]
+    [LoggerMessage(6, LogLevel.Information, "Last process occured at {LastProcessTime}. Processing items")]
     public static partial void BatchProcessIntervalReached(this ILogger logger, DateTime lastProcessTime);
 
-    [LoggerMessage(7, LogLevel.Debug, "Max flush interval reached ({TimeSinceLastProcess})",
-        EventName = "BatchProcessMaxFlushIntervalReached")]
+    [LoggerMessage(7, LogLevel.Debug, "Max flush interval reached ({TimeSinceLastProcess})")]
     public static partial void BatchProcessMaxFlushIntervalReached(this ILogger logger, TimeSpan timeSinceLastProcess);
 
-    [LoggerMessage(8, LogLevel.Debug, "Last message received {TimeSinceLastMessage} ago. Waiting {WaitTime} until next flush interval",
-        EventName = "BatchProcessMinFlushIntervalNotReached")]
+    [LoggerMessage(8, LogLevel.Debug, "Last message received {TimeSinceLastMessage} ago. Waiting {WaitTime} until next flush interval")]
     public static partial void BatchProcessMinFlushIntervalNotReached(this ILogger logger, TimeSpan timeSinceLastMessage, TimeSpan waitTime);
 
-    [LoggerMessage(9, LogLevel.Debug, "Waiting {WaitTime} until next flush interval",
-        EventName = "BatchProcessIntervalWait")]
+    [LoggerMessage(9, LogLevel.Debug, "Waiting {WaitTime} until next flush interval")]
     public static partial void BatchProcessIntervalWait(this ILogger logger, TimeSpan waitTime);
 
-    [LoggerMessage(10, LogLevel.Information, "Processing {Count} items...", EventName = "BatchProcessStart")]
+    [LoggerMessage(10, LogLevel.Information, "Processing {Count} items...")]
     public static partial void BatchProcessStart(this ILogger logger, int count);
 
-    [LoggerMessage(11, LogLevel.Information, "Processed {Count} items in {ProcessDuration}",
-        EventName = "BatchProcessCompleted")]
+    [LoggerMessage(11, LogLevel.Information, "Processed {Count} items in {ProcessDuration}")]
     public static partial void BatchProcessCompleted(this ILogger logger, int count, TimeSpan processDuration);
 }

--- a/src/Hosting/Queue/src/LoggerExtensions.cs
+++ b/src/Hosting/Queue/src/LoggerExtensions.cs
@@ -19,7 +19,7 @@ internal static partial class LoggerExtensions
     [LoggerMessage(5, LogLevel.Debug, "Last process occured at {LastProcessTime}. (Time since last process: {TimeSinceLastProcess})")]
     public static partial void LogLastProcessTime(this ILogger logger, DateTime lastProcessTime, TimeSpan timeSinceLastProcess);
 
-    [LoggerMessage(6, LogLevel.Debug, "Waiting {WaitTime} until next flush interval. (Time since message: {TimeSinceLastMessage})")]
+    [LoggerMessage(6, LogLevel.Debug, "Waiting {WaitTime} until next flush interval. (Time since last message: {TimeSinceLastMessage})")]
     public static partial void BatchProcessIntervalWait(this ILogger logger, TimeSpan waitTime, TimeSpan timeSinceLastMessage);
 
     [LoggerMessage(7, LogLevel.Information, "Processing {Count} items (Reason: {Reason})...")]

--- a/src/Hosting/Queue/src/LoggerExtensions.cs
+++ b/src/Hosting/Queue/src/LoggerExtensions.cs
@@ -16,24 +16,15 @@ internal static partial class LoggerExtensions
     [LoggerMessage(4, LogLevel.Warning, "Cannot acknowledge task {DeliveryTag}. Channel is not open")]
     public static partial void AcknowledgeFailureChannelNotOpen(this ILogger logger, ulong deliveryTag);
 
-    [LoggerMessage(5, LogLevel.Information, "Message buffer limit reached ({MessageBufferSize})")]
-    public static partial void BatchProcessMessageBufferReached(this ILogger logger, ushort messageBufferSize);
+    [LoggerMessage(5, LogLevel.Debug, "Last process occured at {LastProcessTime}. (Time since last process: {TimeSinceLastProcess})")]
+    public static partial void LogLastProcessTime(this ILogger logger, DateTime lastProcessTime, TimeSpan timeSinceLastProcess);
 
-    [LoggerMessage(6, LogLevel.Information, "Last process occured at {LastProcessTime}")]
-    public static partial void BatchProcessIntervalReached(this ILogger logger, DateTime lastProcessTime);
+    [LoggerMessage(6, LogLevel.Debug, "Waiting {WaitTime} until next flush interval. (Time since message: {TimeSinceLastMessage})")]
+    public static partial void BatchProcessIntervalWait(this ILogger logger, TimeSpan waitTime, TimeSpan timeSinceLastMessage);
 
-    [LoggerMessage(7, LogLevel.Information, "Max flush interval reached ({TimeSinceLastProcess})")]
-    public static partial void BatchProcessMaxFlushIntervalReached(this ILogger logger, TimeSpan timeSinceLastProcess);
+    [LoggerMessage(7, LogLevel.Information, "Processing {Count} items (Reason: {Reason})...")]
+    public static partial void BatchProcessStart(this ILogger logger, int count, FlushReason reason);
 
-    [LoggerMessage(8, LogLevel.Debug, "Last message received {TimeSinceLastMessage} ago. Waiting {WaitTime} until next flush interval")]
-    public static partial void BatchProcessMinFlushIntervalNotReached(this ILogger logger, TimeSpan timeSinceLastMessage, TimeSpan waitTime);
-
-    [LoggerMessage(9, LogLevel.Debug, "Waiting {WaitTime} until next flush interval")]
-    public static partial void BatchProcessIntervalWait(this ILogger logger, TimeSpan waitTime);
-
-    [LoggerMessage(10, LogLevel.Information, "Processing {Count} items...")]
-    public static partial void BatchProcessStart(this ILogger logger, int count);
-
-    [LoggerMessage(11, LogLevel.Information, "Processed {Count} items in {ProcessDuration}")]
+    [LoggerMessage(8, LogLevel.Information, "Processed {Count} items in {ProcessDuration}")]
     public static partial void BatchProcessCompleted(this ILogger logger, int count, TimeSpan processDuration);
 }

--- a/src/Hosting/Queue/src/QueueHostedService.cs
+++ b/src/Hosting/Queue/src/QueueHostedService.cs
@@ -11,7 +11,6 @@ using Queues.RabbitMq;
 /// <typeparam name="TMessage"></typeparam>
 /// <typeparam name="TOptions"></typeparam>
 public abstract class QueueHostedService<TMessage, TOptions> : BaseQueueHostedService<TOptions>
-    where TMessage : class, new()
     where TOptions : QueueHostedServiceOptions
 {
     /// <summary>
@@ -48,7 +47,7 @@ public abstract class QueueHostedService<TMessage, TOptions> : BaseQueueHostedSe
     /// <param name="cancellationToken"></param>
     private async Task OnMessageAsync(MessageContext<TMessage> messageContext, CancellationToken cancellationToken)
     {
-        Logger.QueueMessageReceived();
+        Logger.QueueMessageReceived(messageContext.Id, messageContext.Timestamp);
 
         try
         {

--- a/src/Hosting/Queue/src/QueueHostedService.cs
+++ b/src/Hosting/Queue/src/QueueHostedService.cs
@@ -1,6 +1,5 @@
 namespace ClickView.GoodStuff.Hosting.Queue;
 
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Queues.RabbitMq;
@@ -11,122 +10,27 @@ using Queues.RabbitMq;
 /// </summary>
 /// <typeparam name="TMessage"></typeparam>
 /// <typeparam name="TOptions"></typeparam>
-public abstract class QueueHostedService<TMessage, TOptions> : IHostedService, IAsyncDisposable
+public abstract class QueueHostedService<TMessage, TOptions> : BaseQueueHostedService<TOptions>
     where TMessage : class, new()
     where TOptions : QueueHostedServiceOptions
 {
-    private readonly SemaphoreSlim _subscriptionLock = new(1, 1);
-    private readonly IQueueClient _queueClient;
-    private readonly string _name;
-    private SubscriptionContext? _subscriptionContext;
-    private bool _disposed;
-
-    /// <summary>
-    /// Gets the <see cref="ILogger"/>.
-    /// </summary>
-    protected readonly ILogger Logger;
-
-    /// <summary>
-    /// Gets the options.
-    /// </summary>
-    protected readonly TOptions Options;
-
     /// <summary>
     /// Initialises a new instance of <see cref="QueueHostedService{TMessage,TOptions}"/>.
     /// </summary>
     /// <param name="options"></param>
     /// <param name="loggerFactory"></param>
-    protected QueueHostedService(IOptions<TOptions> options, ILoggerFactory loggerFactory)
+    protected QueueHostedService(IOptions<TOptions> options, ILoggerFactory loggerFactory) : base(options, loggerFactory)
     {
-        var type = GetType();
-
-        _name = type.Name;
-        Options = options.Value;
-        Logger = loggerFactory.CreateLogger(type);
-
-        _queueClient = new RabbitMqClient(CreateOptions(Options, loggerFactory));
-    }
-
-    /// <summary>
-    /// Triggered when the application host is ready to start the service.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        CheckDisposed();
-
-        await _subscriptionLock.WaitAsync(cancellationToken);
-
-        try
-        {
-            // If we have a context, don't start again
-            if (_subscriptionContext is not null)
-                throw new InvalidOperationException($"Cannot start already started service {_name} ");
-
-            var queueName = Options.QueueName;
-
-            if (string.IsNullOrWhiteSpace(queueName))
-                throw new ArgumentException($"{nameof(QueueHostedServiceOptions.QueueName)} is required");
-
-            _subscriptionContext = await _queueClient.SubscribeAsync<TMessage>(queueName,
-                OnMessageAsync,
-                new SubscribeOptions {PrefetchCount = Options.ConcurrentTaskCount},
-                cancellationToken);
-        }
-        finally
-        {
-            _subscriptionLock.Release();
-        }
-
-        Logger.LogInformation("Queue service started - {Name}", _name);
-    }
-
-    /// <summary>
-    /// Triggered when the application host is performing a graceful shutdown.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        CheckDisposed();
-
-        await _subscriptionLock.WaitAsync(cancellationToken);
-
-        try
-        {
-            var subContext = _subscriptionContext;
-
-            if (subContext is not null)
-            {
-                await subContext.DisposeAsync();
-                _subscriptionContext = null;
-            }
-        }
-        finally
-        {
-            _subscriptionLock.Release();
-        }
-
-        Logger.LogInformation("Queue service stopped - {Name}", _name);
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
+    protected override Task<SubscriptionContext> SubscribeAsync(IQueueClient queueClient, string queueName,
+        CancellationToken cancellationToken)
     {
-        if (_disposed)
-            return;
-
-        _disposed = true;
-
-        // If we still have an open subscription, Dispose it
-        if (_subscriptionContext != null)
-            await _subscriptionContext.DisposeAsync();
-
-        // Then finally dispose the client
-        await _queueClient.DisposeAsync();
-
-        // Clean up everything else
-        _subscriptionLock.Dispose();
+        return queueClient.SubscribeAsync<TMessage>(queueName,
+            OnMessageAsync,
+            new SubscribeOptions {PrefetchCount = Options.ConcurrentTaskCount},
+            cancellationToken);
     }
 
     /// <summary>
@@ -136,34 +40,6 @@ public abstract class QueueHostedService<TMessage, TOptions> : IHostedService, I
     /// <param name="token"></param>
     /// <returns></returns>
     protected abstract Task OnMessageAsync(TMessage message, CancellationToken token);
-
-    private static RabbitMqClientOptions CreateOptions(QueueHostedServiceOptions options, ILoggerFactory loggerFactory)
-    {
-        var host = options.Host;
-
-        if (string.IsNullOrWhiteSpace(host))
-            throw new ArgumentException($"{nameof(QueueHostedServiceOptions.Host)} is required");
-
-        var o = new RabbitMqClientOptions
-        {
-            Host = host,
-            Port = options.Port,
-            Username = options.Username,
-            Password = options.Password,
-            ConnectionTimeout = options.ConnectionTimeout,
-            EnableSsl = options.EnableSsl,
-            IgnoreSslErrors = options.IgnoreSslErrors,
-            LoggerFactory = loggerFactory
-        };
-
-        if (options.SslVersion != null)
-            o.SslVersion = options.SslVersion.Value;
-
-        if (options.Serializer != null)
-            o.Serializer = options.Serializer;
-
-        return o;
-    }
 
     /// <summary>
     /// Triggered when a message is received from the configured queue.
@@ -189,11 +65,5 @@ public abstract class QueueHostedService<TMessage, TOptions> : IHostedService, I
                 Logger.LogWarning("Cannot acknowledge task. Channel is not open");
             }
         }
-    }
-
-    private void CheckDisposed()
-    {
-        if (_disposed)
-            throw new ObjectDisposedException(GetType().Name);
     }
 }

--- a/src/Hosting/Queue/src/QueueHostedService.cs
+++ b/src/Hosting/Queue/src/QueueHostedService.cs
@@ -48,7 +48,7 @@ public abstract class QueueHostedService<TMessage, TOptions> : BaseQueueHostedSe
     /// <param name="cancellationToken"></param>
     private async Task OnMessageAsync(MessageContext<TMessage> messageContext, CancellationToken cancellationToken)
     {
-        Logger.LogDebug("Queue message received");
+        Logger.QueueMessageReceived();
 
         try
         {

--- a/src/Hosting/Queue/src/QueueHostedServiceOptions.cs
+++ b/src/Hosting/Queue/src/QueueHostedServiceOptions.cs
@@ -1,65 +1,12 @@
 namespace ClickView.GoodStuff.Hosting.Queue;
 
-using System.Security.Authentication;
-using Queues.RabbitMq.Serialization;
-
 /// <summary>
 /// Options for the <see cref="QueueHostedService{TMessage,TOptions}"/>
 /// </summary>
-public abstract class QueueHostedServiceOptions
+public abstract class QueueHostedServiceOptions : BaseQueueHostedServiceOptions
 {
-    /// <summary>
-    /// The name of the queue to subscribe to.
-    /// </summary>
-    public string? QueueName { get; set; }
-
-    /// <summary>
-    /// The hostname or network address of the queue server in which to connect.
-    /// </summary>
-    public string? Host { get; set; }
-
-    /// <summary>
-    /// The port that the queue server is listening to.
-    /// </summary>
-    public ushort Port { get; set; } = 5672;
-
-    /// <summary>
-    /// The username of the user for the queue.
-    /// </summary>
-    public string? Username { get; set; }
-
-    /// <summary>
-    /// The password of the user for the queue.
-    /// </summary>
-    public string? Password { get; set; }
-
-    /// <summary>
-    /// Timeout for connection attempts
-    /// </summary>
-    public TimeSpan? ConnectionTimeout { get; set; }
-
-    /// <summary>
-    /// Set to true to enable SSL
-    /// </summary>
-    public bool EnableSsl { get; set; }
-
-    /// <summary>
-    /// Set to false to ignore SSL errors
-    /// </summary>
-    public bool IgnoreSslErrors { get; set; }
-
-    /// <summary>
-    /// The TLS protocol version. Set to None to let the OS decide
-    /// </summary>
-    public SslProtocols? SslVersion { get; set; }
-
     /// <summary>
     /// The number of tasks to run concurrently.
     /// </summary>
     public ushort ConcurrentTaskCount { get; set; } = 1;
-
-    /// <summary>
-    /// The serializer to use for deserializing messages from the Queue
-    /// </summary>
-    public IMessageSerializer? Serializer { get; set; }
 }


### PR DESCRIPTION
Requires https://github.com/clickviewapp/GoodStuff/pull/165 to be merged first

# ClickView.GoodStuff.Hosting.Queues
Added new `BatchQueueHostedService` worker.

This worker will buffer messages internally until either the `BatchSize` is reached or one of the `Min/MaxFlushIntervals` are reached. The messages are not acknowledged until the processing is completed.

## Settings
`BatchSzie` is the maximum number of messages we will buffer at once. if this is reached then the messages will be processed.

`MinFlushInterval` is our loop delay time, so we check (by default) every 5 seconds. If no message is received in 5 seconds then we flush the buffer.

`MaxFlushInterval` is the maximum allowed time between processing allowed. Consider this scenario:
- `BatchSzie` is set to 1000
- `MinFlushInterval` is set to 10 seconds
- We receive a message every 5 seconds

Without `MaxFlushInterval`, a message could sit in the buffer for 5x1000 seconds (~83 minutes). Setting a `MaxFlushInterval` of 5 minutes would mean that the buffer is flushed every 5 minutes.



