### PR TITLE
Net8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,12 +7,12 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/ClickView.GoodStuff.sln
+++ b/ClickView.GoodStuff.sln
@@ -49,6 +49,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		.editorconfig = .editorconfig
+		.github\dependabot.yml = .github\dependabot.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Id Generators", "Id Generators", "{9478C56E-C226-4DD9-AC2E-0A4E9085414D}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <LangVersion>10.0</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
     </PropertyGroup>

--- a/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore/src/ClickView.GoodStuff.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 

--- a/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
+++ b/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/AspNetCore/Authentication/Abstractions/src/ClickView.GoodStuff.AspNetCore.Authentication.Abstractions.csproj
+++ b/src/AspNetCore/Authentication/Abstractions/src/ClickView.GoodStuff.AspNetCore.Authentication.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 

--- a/src/AspNetCore/Authentication/Authentication/src/ClickView.GoodStuff.AspNetCore.Authentication.csproj
+++ b/src/AspNetCore/Authentication/Authentication/src/ClickView.GoodStuff.AspNetCore.Authentication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 

--- a/src/AspNetCore/Authentication/Authentication/src/Endpoints/BackChannelLogoutEndpoint.cs
+++ b/src/AspNetCore/Authentication/Authentication/src/Endpoints/BackChannelLogoutEndpoint.cs
@@ -30,8 +30,8 @@
         {
             _logger.LogDebug("Processing Back-Channel logout");
 
-            context.Response.Headers.Add("Cache-Control", "no-cache, no-store");
-            context.Response.Headers.Add("Pragma", "no-cache");
+            context.Response.Headers.CacheControl = "no-cache, no-store";
+            context.Response.Headers.Pragma = "no-cache";
 
             if (!context.Request.HasFormContentType)
             {

--- a/src/AspNetCore/Authentication/Authentication/src/Infrastructure/PostCookieAuthenticationOptions.cs
+++ b/src/AspNetCore/Authentication/Authentication/src/Infrastructure/PostCookieAuthenticationOptions.cs
@@ -12,7 +12,7 @@
             _ticketStore = ticketStore;
         }
 
-        public void PostConfigure(string name, CookieAuthenticationOptions options)
+        public void PostConfigure(string? name, CookieAuthenticationOptions options)
         {
             options.SessionStore = _ticketStore;
         }

--- a/src/AspNetCore/Authentication/Authentication/src/TokenValidation/TokenValidatorOptionsConfigureOptions.cs
+++ b/src/AspNetCore/Authentication/Authentication/src/TokenValidation/TokenValidatorOptionsConfigureOptions.cs
@@ -12,7 +12,7 @@
             _handlerOptions = handlerOptions.Value;
         }
 
-        public void PostConfigure(string name, TokenValidatorOptions options)
+        public void PostConfigure(string? name, TokenValidatorOptions options)
         {
             options = options ?? throw new ArgumentNullException(nameof(options));
 

--- a/src/AspNetCore/Authentication/StackExchangeRedis/src/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.csproj
+++ b/src/AspNetCore/Authentication/StackExchangeRedis/src/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/AspNetCore/Authentication/StackExchangeRedis/test/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.Tests.csproj
+++ b/src/AspNetCore/Authentication/StackExchangeRedis/test/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/AspNetCore/MaxMind/src/ClickView.GoodStuff.AspNetCore.MaxMind.csproj
+++ b/src/AspNetCore/MaxMind/src/ClickView.GoodStuff.AspNetCore.MaxMind.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 
@@ -19,5 +19,5 @@
         <InternalsVisibleTo Include="$(AssemblyName).Tests" />
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
-    
+
 </Project>

--- a/src/AspNetCore/MaxMind/test/ClickView.GoodStuff.AspNetCore.MaxMind.Tests.csproj
+++ b/src/AspNetCore/MaxMind/test/ClickView.GoodStuff.AspNetCore.MaxMind.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Hosting/Queue/src/BatchQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BatchQueueHostedService.cs
@@ -222,7 +222,7 @@ public abstract class BatchQueueHostedService<TMessage, TOptions> : BaseQueueHos
                     Debug.Assert(reason.HasValue);
 
                     Logger.LogLastProcessTime(lastProcess, timeSinceLastProcess);
-                    await ProcessItemsAsync(snapshot, latestDeliveryTag, reason!.Value, cancellationToken);
+                    await ProcessItemsAsync(snapshot, latestDeliveryTag, reason.Value, cancellationToken);
                 }
 
                 Logger.BatchProcessIntervalWait(waitTime, timeSinceLastMessage);

--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -87,14 +87,14 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
     }
 
     /// <inheritdoc />
-    public int CompareTo(object? value)
+    public int CompareTo(object? obj)
     {
-        if (value == null)
+        if (obj == null)
             return 1;
 
         // Need to use compare because subtraction will wrap
         // to positive for very large neg numbers, etc.
-        if (value is IdLong i)
+        if (obj is IdLong i)
         {
             if (Value < i.Value) return -1;
             if (Value > i.Value) return 1;

--- a/src/IdGenerators/Abstractions/test/ClickView.GoodStuff.IdGenerators.Abstractions.Tests.csproj
+++ b/src/IdGenerators/Abstractions/test/ClickView.GoodStuff.IdGenerators.Abstractions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/IdGenerators/IdGen/test/ClickView.GoodStuff.IdGenerators.IdGen.Tests.csproj
+++ b/src/IdGenerators/IdGen/test/ClickView.GoodStuff.IdGenerators.IdGen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Queues/RabbitMq/src/MessageContext.cs
+++ b/src/Queues/RabbitMq/src/MessageContext.cs
@@ -56,7 +56,7 @@ public class MessageContext<TData>
     /// Rejects one or more messages
     /// </summary>
     /// <param name="multiple">If true, reject all outstanding delivery tags up to and including the delivery tag</param>
-    /// <param name="requeue">If true, requeue the delivery (or multiple deliveries if <see cref="multiple"/> is true)) with the specified delivery tag</param>
+    /// <param name="requeue">If true, requeue the delivery (or multiple deliveries if <paramref name="multiple"/> is true)) with the specified delivery tag</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns></returns>
     public Task NegativeAcknowledgeAsync(bool multiple = false, bool requeue = true, CancellationToken cancellationToken = default)

--- a/src/Queues/RabbitMq/src/SubscriptionContext.cs
+++ b/src/Queues/RabbitMq/src/SubscriptionContext.cs
@@ -61,7 +61,7 @@ public class SubscriptionContext : IAsyncDisposable
     /// </summary>
     /// <param name="deliveryTag">The delivery tag of the message to acknowledge</param>
     /// <param name="multiple">If true, reject all outstanding delivery tags up to and including the delivery tag</param>
-    /// <param name="requeue">If true, requeue the delivery (or multiple deliveries if <see cref="multiple"/> is true)) with the specified delivery tag</param>
+    /// <param name="requeue">If true, requeue the delivery (or multiple deliveries if <paramref name="multiple"/> is true)) with the specified delivery tag</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns></returns>
     public Task NegativeAcknowledgeAsync(ulong deliveryTag, bool multiple = false, bool requeue = true,

--- a/src/Repositories/MsSql/test/ClickView.GoodStuff.Repositories.MsSql.Tests/ClickView.GoodStuff.Repositories.MsSql.Tests.csproj
+++ b/src/Repositories/MsSql/test/ClickView.GoodStuff.Repositories.MsSql.Tests/ClickView.GoodStuff.Repositories.MsSql.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Repositories/MySql/src/MySqlRepositoryOptions.cs
+++ b/src/Repositories/MySql/src/MySqlRepositoryOptions.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The number of times to retry a query on a fail-over error
         /// </summary>
-        public int FailOverRetryCount { get; set; } = 0;
+        public int FailOverRetryCount { get; set; }
 
         /// <summary>
         /// The function that provides the duration to wait for for a particular fail-over retry attempt

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/ClickView.GoodStuff.Repositories.MySql.TestApp.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/ClickView.GoodStuff.Repositories.MySql.TestApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
- Update build to use .NET8
- Update test projects to run using .NET8
- Set LangVersion to 12
- Stop warning about missing xmldocs (very noisy)
- Fix various warnings
- Update all `ClickView.GoodStuff.AspNetCore*` projects to target .net8