### PR TITLE
RabbitMQ: EnablePublisherConfirms option

### DIFF
--- a/src/Queues/RabbitMq/src/EnqueueOptions.cs
+++ b/src/Queues/RabbitMq/src/EnqueueOptions.cs
@@ -5,5 +5,11 @@ public class EnqueueOptions
     public bool Persistent { get; init; }
     public string RoutingKey { get; init; } = string.Empty;
 
+    /// <summary>
+    /// If true, enables publisher confirm tracking.
+    /// See <see href="https://www.rabbitmq.com/docs/confirms#publisher-confirms"/> for more information.
+    /// </summary>
+    public bool EnablePublisherConfirms { get; set; }
+
     internal static readonly EnqueueOptions Default = new();
 }


### PR DESCRIPTION
Added `EnablePublisherConfirms` to `EnqueueOptions` for `RabbitMqClient`

This lets you enable [publisher confirms](https://www.rabbitmq.com/docs/confirms#publisher-confirms) which will ensure that messages have been received by the rabbitmq server at the expense of throughput.

For now I've left this `false` by default to match existing behaviour but we should change this so they are enabled by default