### PR TITLE
RabbitMQ make LoggerFactory nullable

### DIFF
--- a/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
@@ -10,14 +10,14 @@ internal class RabbitMqCallbackConsumer<TData>(
     Func<MessageContext<TData>, CancellationToken, Task> callback,
     CountWaiter taskWaiter,
     IMessageSerializer serializer,
-    ILogger<RabbitMqCallbackConsumer<TData>> logger)
+    ILogger<RabbitMqCallbackConsumer<TData>>? logger)
     : AsyncDefaultBasicConsumer(channel)
 {
     public override Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
         string exchange, string routingKey, IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body,
         CancellationToken cancellationToken = default)
     {
-        logger.QueueMessageReceived(deliveryTag, consumerTag, exchange, redelivered);
+        logger?.QueueMessageReceived(deliveryTag, consumerTag, exchange, redelivered);
 
         return HandleBasicDeliverAsync(deliveryTag, body, cancellationToken);
     }
@@ -51,7 +51,7 @@ internal class RabbitMqCallbackConsumer<TData>(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Unhandled exception when processing queue message");
+            logger?.LogError(ex, "Unhandled exception when processing queue message");
             throw;
         }
     }

--- a/src/Queues/RabbitMq/src/RabbitMqClientException.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientException.cs
@@ -1,8 +1,3 @@
 namespace ClickView.GoodStuff.Queues.RabbitMq;
 
-public class RabbitMqClientException : Exception
-{
-    public RabbitMqClientException(string message) : base(message)
-    {
-    }
-}
+public class RabbitMqClientException(string message) : Exception(message);

--- a/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
@@ -2,7 +2,6 @@ namespace ClickView.GoodStuff.Queues.RabbitMq;
 
 using System.Security.Authentication;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Serialization;
 
@@ -56,7 +55,7 @@ public class RabbitMqClientOptions : IOptions<RabbitMqClientOptions>
     /// <summary>
     /// The logger factory to enable logging
     /// </summary>
-    public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
+    public ILoggerFactory? LoggerFactory { get; set; }
 
     /// <summary>
     /// Set to a value greater than one to enable concurrent processing. For a concurrency greater than one,

--- a/src/Queues/RabbitMq/src/SubscriptionContext.cs
+++ b/src/Queues/RabbitMq/src/SubscriptionContext.cs
@@ -11,7 +11,7 @@ public class SubscriptionContext : IAsyncDisposable
     private readonly IChannel _channel;
     private readonly ActiveSubscriptions _subscriptions;
     private readonly CountWaiter _taskWaiter;
-    private readonly ILogger<SubscriptionContext> _logger;
+    private readonly ILogger<SubscriptionContext>? _logger;
     private string? _consumerTag;
     private bool _disposed;
 
@@ -20,7 +20,7 @@ public class SubscriptionContext : IAsyncDisposable
         IChannel channel,
         ActiveSubscriptions subscriptions,
         CountWaiter taskWaiter,
-        ILogger<SubscriptionContext> logger)
+        ILogger<SubscriptionContext>? logger)
     {
         _queueName = queueName;
         _channel = channel;
@@ -48,7 +48,7 @@ public class SubscriptionContext : IAsyncDisposable
     {
         CheckDisposed();
 
-        _logger.SendingAcknowledge(deliveryTag);
+        _logger?.SendingAcknowledge(deliveryTag);
 
         return _channel.BasicAckAsync(
             deliveryTag: deliveryTag,
@@ -69,7 +69,7 @@ public class SubscriptionContext : IAsyncDisposable
     {
         CheckDisposed();
 
-        _logger.SendingNegativeAcknowledge(deliveryTag);
+        _logger?.SendingNegativeAcknowledge(deliveryTag);
 
         return _channel.BasicNackAsync(
             deliveryTag: deliveryTag,
@@ -84,20 +84,20 @@ public class SubscriptionContext : IAsyncDisposable
         if (_disposed)
             return;
 
-        _logger.LogDebug("Disposing subscription context...");
+        _logger?.LogDebug("Disposing subscription context...");
 
         // Unsubscribe from the queue to stop receiving any new messages
-        _logger.LogDebug("Unsubscribing from queue {QueueName}", _queueName);
+        _logger?.LogDebug("Unsubscribing from queue {QueueName}", _queueName);
         Debug.Assert(_consumerTag != null);
         await _channel.BasicCancelAsync(_consumerTag);
 
         // Wait for all tasks to complete before closing the connection
         // If we close the connection first then the tasks cant ack
-        _logger.LogDebug("Waiting for all tasks to finish...");
+        _logger?.LogDebug("Waiting for all tasks to finish...");
         await _taskWaiter.WaitAsync();
 
         // Close the channel
-        _logger.LogDebug("Closing channel");
+        _logger?.LogDebug("Closing channel");
         await _channel.CloseAsync();
 
         // Dispose
@@ -106,7 +106,7 @@ public class SubscriptionContext : IAsyncDisposable
 
         _subscriptions.Remove(this);
 
-        _logger.LogDebug("Subscription context disposed");
+        _logger?.LogDebug("Subscription context disposed");
     }
 
     private void CheckDisposed()


### PR DESCRIPTION
Instead of adding a `NullLoggerFactory`, make the `LoggerFactory` property nullable so we can skip setting up logging if we don't have a logger