### PR TITLE
Remove .Default methods from IMessageSerializer

### DIFF
--- a/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClientOptions.cs
@@ -50,7 +50,7 @@ public class RabbitMqClientOptions : IOptions<RabbitMqClientOptions>
     /// <summary>
     /// The serializer to use for serializing and deserializing messages
     /// </summary>
-    public IMessageSerializer Serializer { get; set; } = NewtonsoftJsonMessageSerializer.Default;
+    public IMessageSerializer Serializer { get; set; } = new NewtonsoftJsonMessageSerializer();
 
     /// <summary>
     /// The logger factory to enable logging

--- a/src/Queues/RabbitMq/src/Serialization/NewtonsoftJsonMessageSerializer.cs
+++ b/src/Queues/RabbitMq/src/Serialization/NewtonsoftJsonMessageSerializer.cs
@@ -16,8 +16,6 @@ public class NewtonsoftJsonMessageSerializer : IMessageSerializer
         _settings = settings;
     }
 
-    public static readonly NewtonsoftJsonMessageSerializer Default = new();
-
     private static JsonSerializerSettings GetDefaultSettings()
     {
         return new JsonSerializerSettings();

--- a/src/Queues/RabbitMq/src/Serialization/SystemTextJsonMessageSerializer.cs
+++ b/src/Queues/RabbitMq/src/Serialization/SystemTextJsonMessageSerializer.cs
@@ -15,8 +15,6 @@ public class SystemTextJsonMessageSerializer : IMessageSerializer
         _options = options;
     }
 
-    public static readonly SystemTextJsonMessageSerializer Default = new();
-
     private static JsonSerializerOptions GetDefaultOptions()
     {
         return new JsonSerializerOptions


### PR DESCRIPTION
These are mostly redundant