### PR TITLE
Netstandard2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,6 @@
   <PropertyGroup>
     <CoreTargetFrameworks>net8.0;net9.0</CoreTargetFrameworks>
     <FullTargetFrameworks>net462;netstandard2.0;net8.0;net9.0</FullTargetFrameworks>
-    <TestTargetFramework>net9.0</TestTargetFramework>
+    <TestTargetFrameworks>net9.0</TestTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
     <CoreTargetFrameworks>net8.0;net9.0</CoreTargetFrameworks>
-    <FullTargetFrameworks>net462;netstandard2.1;net8.0;net9.0</FullTargetFrameworks>
+    <FullTargetFrameworks>net462;netstandard2.0;net8.0;net9.0</FullTargetFrameworks>
     <TestTargetFramework>net9.0</TestTargetFramework>
   </PropertyGroup>
 </Project>

--- a/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
+++ b/src/AspNetCore/AspNetCore/test/ClickView.GoodStuff.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/AspNetCore/Authentication/StackExchangeRedis/test/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.Tests.csproj
+++ b/src/AspNetCore/Authentication/StackExchangeRedis/test/ClickView.GoodStuff.AspNetCore.Authentication.StackExchangeRedis.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/AspNetCore/MaxMind/test/ClickView.GoodStuff.AspNetCore.MaxMind.Tests.csproj
+++ b/src/AspNetCore/MaxMind/test/ClickView.GoodStuff.AspNetCore.MaxMind.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/IdGenerators/Abstractions/src/IdLong.cs
+++ b/src/IdGenerators/Abstractions/src/IdLong.cs
@@ -43,10 +43,10 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
 
         if (value.Length > 0 && value[0] == Prefix)
         {
-#if NETFRAMEWORK
-            var idPart = value.Substring(1);
-#else
+#if NET
             var idPart = value.AsSpan(1);
+#else
+            var idPart = value.Substring(1);
 #endif
 
             return new IdLong(long.Parse(idPart));
@@ -61,18 +61,18 @@ public readonly struct IdLong : IComparable, IComparable<IdLong>, IEquatable<IdL
     /// <param name="value"></param>
     /// <param name="result"></param>
     /// <returns></returns>
-#if NETFRAMEWORK
-    public static bool TryParse(string? value, out IdLong result)
-#else
+#if NET
     public static bool TryParse([NotNullWhen(true)] string? value, out IdLong result)
+#else
+    public static bool TryParse(string? value, out IdLong result)
 #endif
     {
         if (value is { Length: > 0 } && value[0] == Prefix)
         {
-#if NETFRAMEWORK
-            var idPart = value.Substring(1);
-#else
+#if NET
             var idPart = value.AsSpan(1);
+#else
+            var idPart = value.Substring(1);
 #endif
 
             if (long.TryParse(idPart, out var longValue))

--- a/src/IdGenerators/Abstractions/test/ClickView.GoodStuff.IdGenerators.Abstractions.Tests.csproj
+++ b/src/IdGenerators/Abstractions/test/ClickView.GoodStuff.IdGenerators.Abstractions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/IdGenerators/IdGen/test/ClickView.GoodStuff.IdGenerators.IdGen.Tests.csproj
+++ b/src/IdGenerators/IdGen/test/ClickView.GoodStuff.IdGenerators.IdGen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Repositories/Abstractions/src/RepositoryConnectionOptions.cs
+++ b/src/Repositories/Abstractions/src/RepositoryConnectionOptions.cs
@@ -42,10 +42,10 @@
             {
                 try
                 {
-#if NETFRAMEWORK
-                    return (T) Enum.Parse(typeof(T), value, ignoreCase: true);
-#else
+#if NET
                     return Enum.Parse<T>(value, ignoreCase: true);
+#else
+                    return (T) Enum.Parse(typeof(T), value, ignoreCase: true);
 #endif
                 }
                 catch (Exception ex) when (ex is not ArgumentException)

--- a/src/Repositories/MsSql/test/ClickView.GoodStuff.Repositories.MsSql.Tests/ClickView.GoodStuff.Repositories.MsSql.Tests.csproj
+++ b/src/Repositories/MsSql/test/ClickView.GoodStuff.Repositories.MsSql.Tests/ClickView.GoodStuff.Repositories.MsSql.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/ClickView.GoodStuff.Repositories.MySql.TestApp.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.TestApp/ClickView.GoodStuff.Repositories.MySql.TestApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>$(TestTargetFramework)</TargetFramework>
+      <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
       <GenerateDocumentationFile>false</GenerateDocumentationFile>
       <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
+++ b/src/Repositories/MySql/test/ClickView.GoodStuff.Repositories.MySql.Tests/ClickView.GoodStuff.Repositories.MySql.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
- Re-target `netstandard2.0` instead of `netstandard2.1`
- Rename `TestTargetFramework` to `TestTargetFrameworks` to match other projects