### PR TITLE
Better message priority

### DIFF
--- a/src/Queues/RabbitMq/src/EnqueueOptions.cs
+++ b/src/Queues/RabbitMq/src/EnqueueOptions.cs
@@ -14,7 +14,7 @@ public class EnqueueOptions
     /// <summary>
     /// The priority of the message.
     /// </summary>
-    public byte Priority { get; set; }
+    public MessagePriority Priority { get; set; } = MessagePriority.Normal;
 
     internal static readonly EnqueueOptions Default = new();
 }

--- a/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
@@ -19,10 +19,11 @@ internal class RabbitMqCallbackConsumer<TData>(
     {
         logger?.QueueMessageReceived(deliveryTag, consumerTag, exchange, redelivered);
 
-        return HandleBasicDeliverAsync(deliveryTag, body, cancellationToken);
+        return HandleBasicDeliverAsync(deliveryTag, body, properties, redelivered, cancellationToken);
     }
 
-    private async Task HandleBasicDeliverAsync(ulong deliveryTag, ReadOnlyMemory<byte> body, CancellationToken cancellationToken)
+    private async Task HandleBasicDeliverAsync(ulong deliveryTag, ReadOnlyMemory<byte> body,
+        IReadOnlyBasicProperties properties, bool reDelivered, CancellationToken cancellationToken)
     {
         try
         {
@@ -36,6 +37,8 @@ internal class RabbitMqCallbackConsumer<TData>(
                 deliveryTag: deliveryTag,
                 timestamp: DateTimeOffset.FromUnixTimeSeconds(message.Timestamp).UtcDateTime,
                 id: message.Id,
+                priority: new MessagePriority(properties.Priority),
+                reDelivered: reDelivered,
                 subscriptionContext: subscriptionContext
             );
 

--- a/src/Queues/RabbitMq/src/MessageContext.cs
+++ b/src/Queues/RabbitMq/src/MessageContext.cs
@@ -4,34 +4,47 @@ public class MessageContext<TData>
 {
     private readonly SubscriptionContext _subscriptionContext;
 
-    internal MessageContext(TData data, ulong deliveryTag, DateTime timestamp, string id, SubscriptionContext subscriptionContext)
+    internal MessageContext(TData data, ulong deliveryTag, DateTime timestamp, string id, MessagePriority priority,
+        SubscriptionContext subscriptionContext, bool reDelivered)
     {
         _subscriptionContext = subscriptionContext;
+        ReDelivered = reDelivered;
         Data = data;
         DeliveryTag = deliveryTag;
         Timestamp = timestamp;
         Id = id;
+        Priority = priority;
     }
 
     /// <summary>
     /// The message data
     /// </summary>
-    public TData Data { get; set; }
+    public TData Data { get; }
 
     /// <summary>
     /// The RabbitMQ delivery tag
     /// </summary>
-    public ulong DeliveryTag { get; set; }
+    public ulong DeliveryTag { get; }
 
     /// <summary>
     /// The timestamp the message was enqueued
     /// </summary>
-    public DateTime Timestamp { get; set; }
+    public DateTime Timestamp { get; }
 
     /// <summary>
     /// The unique ID for this message
     /// </summary>
-    public string Id { get; set; }
+    public string Id { get; }
+
+    /// <summary>
+    /// The priority of the message
+    /// </summary>
+    public MessagePriority Priority { get; }
+
+    /// <summary>
+    /// True if the message has been re-delivered
+    /// </summary>
+    public bool ReDelivered { get; }
 
     /// <summary>
     /// Returns true if the RabbitMQ channel is open

--- a/src/Queues/RabbitMq/src/MessagePriority.cs
+++ b/src/Queues/RabbitMq/src/MessagePriority.cs
@@ -1,6 +1,8 @@
 namespace ClickView.GoodStuff.Queues.RabbitMq;
 
-public readonly struct MessagePriority(byte value)
+using System.Diagnostics.CodeAnalysis;
+
+public readonly struct MessagePriority(byte value) : IEquatable<MessagePriority>
 {
     public byte Value { get; } = value;
 
@@ -21,4 +23,29 @@ public readonly struct MessagePriority(byte value)
 
     public static implicit operator byte(MessagePriority priority) => priority.Value;
     public static implicit operator MessagePriority(byte value) => new(value);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return base.Equals(obj);
+    }
+
+    public bool Equals(MessagePriority other)
+    {
+        return Value == other.Value;
+    }
+
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    public static bool operator ==(MessagePriority left, MessagePriority right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(MessagePriority left, MessagePriority right)
+    {
+        return !left.Equals(right);
+    }
 }

--- a/src/Queues/RabbitMq/src/MessagePriority.cs
+++ b/src/Queues/RabbitMq/src/MessagePriority.cs
@@ -1,0 +1,24 @@
+namespace ClickView.GoodStuff.Queues.RabbitMq;
+
+public readonly struct MessagePriority(byte value)
+{
+    public byte Value { get; } = value;
+
+    /// <summary>
+    /// Returns true if the message priority is between 0 and 4.
+    /// </summary>
+    /// <returns></returns>
+    public bool IsNormalPriority() => Value < 5;
+
+    /// <summary>
+    /// Returns true if the message priority is higher than 4.
+    /// </summary>
+    /// <returns></returns>
+    public bool IsHighPriority() => Value > 4;
+
+    public static readonly MessagePriority High = new(5);
+    public static readonly MessagePriority Normal = new(0);
+
+    public static implicit operator byte(MessagePriority priority) => priority.Value;
+    public static implicit operator MessagePriority(byte value) => new(value);
+}

--- a/src/Queues/RabbitMq/src/MessagePriority.cs
+++ b/src/Queues/RabbitMq/src/MessagePriority.cs
@@ -24,28 +24,10 @@ public readonly struct MessagePriority(byte value) : IEquatable<MessagePriority>
     public static implicit operator byte(MessagePriority priority) => priority.Value;
     public static implicit operator MessagePriority(byte value) => new(value);
 
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        return base.Equals(obj);
-    }
+    public override int GetHashCode() => Value.GetHashCode();
 
-    public bool Equals(MessagePriority other)
-    {
-        return Value == other.Value;
-    }
-
-    public override int GetHashCode()
-    {
-        return Value.GetHashCode();
-    }
-
-    public static bool operator ==(MessagePriority left, MessagePriority right)
-    {
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(MessagePriority left, MessagePriority right)
-    {
-        return !left.Equals(right);
-    }
+    public override bool Equals([NotNullWhen(true)] object? obj) => base.Equals(obj);
+    public bool Equals(MessagePriority other) => Value == other.Value;
+    public static bool operator ==(MessagePriority left, MessagePriority right) => left.Equals(right);
+    public static bool operator !=(MessagePriority left, MessagePriority right) => !left.Equals(right);
 }

--- a/src/Queues/RabbitMq/src/RabbitMqClient.cs
+++ b/src/Queues/RabbitMq/src/RabbitMqClient.cs
@@ -51,7 +51,7 @@ public class RabbitMqClient : IQueueClient
         var properties = new BasicProperties
         {
             Persistent = options.Persistent,
-            Priority = options.Priority
+            Priority = options.Priority.Value
         };
 
         await channel.BasicPublishAsync(


### PR DESCRIPTION
# MessagePriority
I've changed the `Priority` on the `EnqueueOptions` to be a new struct `MessagePriority` to make it a little easier to interact with quorum queue message priorities (see https://www.rabbitmq.com/docs/quorum-queues#priorities).

Before you had to give it a `byte` which worked well for classic queues, but for quorum queues it swould mean you'd need to use a value of `5` or higher.

Now you can do:

```cs
client.EnqueueAsync(data, new EnqueueOptions
{
    Priority = MessagePriority.High
});
```

If you're still using classic queues, then you'd still do (or whatever the max value is)
```cs
client.EnqueueAsync(data, new EnqueueOptions
{
    Priority = 3
});
```


I've added implicit operators for `byte` so after upgrade everything, consumers should still compile fine.

# Updated MessageContext

I've added some more props to `MessageContext`:
- `Priority`
- `ReDelivered` = if the message has been re-delivered for whatever reason.

And removed the setters as only the ctor should be setting these