### PR TITLE
Queue message

### DIFF
--- a/src/Hosting/Queue/src/BaseQueueMessage.cs
+++ b/src/Hosting/Queue/src/BaseQueueMessage.cs
@@ -1,0 +1,43 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+using Queues.RabbitMq;
+
+public abstract class BaseQueueMessage<TData>
+{
+    protected readonly MessageContext<TData> MessageContext;
+
+    internal BaseQueueMessage(MessageContext<TData> messageContext)
+    {
+        MessageContext = messageContext;
+    }
+
+    /// <summary>
+    /// The message data
+    /// </summary>
+    public TData Data => MessageContext.Data;
+
+    /// <summary>
+    /// The routing key of the message. If not set, this will be an empty string.
+    /// </summary>
+    public string RoutingKey => MessageContext.RoutingKey;
+
+    /// <summary>
+    /// The timestamp the message was enqueued
+    /// </summary>
+    public DateTime Timestamp => MessageContext.Timestamp;
+
+    /// <summary>
+    /// The unique ID for this message
+    /// </summary>
+    public string Id => MessageContext.Id;
+
+    /// <summary>
+    /// The priority of the message
+    /// </summary>
+    public MessagePriority Priority => MessageContext.Priority;
+
+    /// <summary>
+    /// True if the message has been re-delivered
+    /// </summary>
+    public bool ReDelivered => MessageContext.ReDelivered;
+}

--- a/src/Hosting/Queue/src/QueueMessage.cs
+++ b/src/Hosting/Queue/src/QueueMessage.cs
@@ -1,0 +1,35 @@
+namespace ClickView.GoodStuff.Hosting.Queue;
+
+using Queues.RabbitMq;
+
+public sealed class QueueMessage<TData>(MessageContext<TData> messageContext) : BaseQueueMessage<TData>(messageContext)
+{
+    /// <summary>
+    /// Returns true if the message has been acknowledged (either ack or nack).
+    /// </summary>
+    public bool Acknowledged => MessageContext.Acknowledged;
+
+    /// <summary>
+    /// Acknowledges one or more messages
+    /// </summary>
+    /// <param name="multiple">If true, acknowledge all outstanding delivery tags up to and including the delivery tag</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns></returns>
+    public ValueTask AcknowledgeAsync(bool multiple = false, CancellationToken cancellationToken = default)
+    {
+        return MessageContext.AcknowledgeAsync(multiple, cancellationToken);
+    }
+
+    /// <summary>
+    /// Rejects one or more messages
+    /// </summary>
+    /// <param name="multiple">If true, reject all outstanding delivery tags up to and including the delivery tag</param>
+    /// <param name="requeue">If true, requeue the delivery (or multiple deliveries if <paramref name="multiple"/> is true)) with the specified delivery tag</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns></returns>
+    public ValueTask NegativeAcknowledgeAsync(bool multiple = false, bool requeue = true,
+        CancellationToken cancellationToken = default)
+    {
+        return MessageContext.NegativeAcknowledgeAsync(multiple: multiple, requeue: requeue, cancellationToken);
+    }
+}

--- a/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
+++ b/src/Queues/RabbitMq/src/Internal/RabbitMqCallbackConsumer.cs
@@ -19,11 +19,11 @@ internal class RabbitMqCallbackConsumer<TData>(
     {
         logger?.QueueMessageReceived(deliveryTag, consumerTag, exchange, redelivered);
 
-        return HandleBasicDeliverAsync(deliveryTag, body, properties, redelivered, cancellationToken);
+        return HandleBasicDeliverAsync(deliveryTag, body, properties, routingKey, redelivered, cancellationToken);
     }
 
     private async Task HandleBasicDeliverAsync(ulong deliveryTag, ReadOnlyMemory<byte> body,
-        IReadOnlyBasicProperties properties, bool reDelivered, CancellationToken cancellationToken)
+        IReadOnlyBasicProperties properties, string routingKey, bool reDelivered, CancellationToken cancellationToken)
     {
         try
         {
@@ -34,6 +34,7 @@ internal class RabbitMqCallbackConsumer<TData>(
 
             var context = new MessageContext<TData>(
                 data: message.Data,
+                routingKey: routingKey,
                 deliveryTag: deliveryTag,
                 timestamp: DateTimeOffset.FromUnixTimeSeconds(message.Timestamp).UtcDateTime,
                 id: message.Id,


### PR DESCRIPTION
merge after: https://github.com/clickviewapp/GoodStuff/pull/278

# QueueMessage
Added new type `QueueMessage<TData>` to `ClickView.GoodStuff.Hosting.Queue` which is used in `QueueHostedService.OnMessageAsync`. This is basically a wrapper around `MessageContext<>` which means that the implementation here is not directly tied to RabbitMq.

This allows us to access the queue metadata such as `Priority` and `Id` and also lets us ack or nack the item ourselves. If not acked/nacked, the message will be auto acked as usual.


**This is a breaking change** due to `OnMessageAsync` changing from accepting a `TData` to a `QueueMessage<TData>`.


# MessageContext

I've also updated `MessageContext` to include an `Acknowledged` prop which lets users know if the message has been ack/nacked. If the message is acked/nacked a second time, a `InvalidOperationException` is thrown.

Also added `RoutingKey`