### PR TITLE
Fix concurrent queue item handling (re #290)

### DIFF
--- a/src/Hosting/Queue/src/BaseQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BaseQueueHostedService.cs
@@ -192,8 +192,7 @@ public abstract class BaseQueueHostedService<TOptions> : IHostedService, IAsyncD
             ConnectionTimeout = options.ConnectionTimeout,
             EnableSsl = options.EnableSsl,
             IgnoreSslErrors = options.IgnoreSslErrors,
-            LoggerFactory = loggerFactory,
-            ConsumerDispatchConcurrency = options.ConcurrentTaskCount
+            LoggerFactory = loggerFactory
         };
 
         if (options.SslVersion != null)

--- a/src/Hosting/Queue/src/BaseQueueHostedServiceOptions.cs
+++ b/src/Hosting/Queue/src/BaseQueueHostedServiceOptions.cs
@@ -57,9 +57,4 @@ public abstract class BaseQueueHostedServiceOptions
     /// The serializer to use for deserializing messages from the Queue
     /// </summary>
     public IMessageSerializer? Serializer { get; set; }
-
-    /// <summary>
-    /// The number of tasks to run concurrently.
-    /// </summary>
-    public ushort ConcurrentTaskCount { get; set; } = 1;
 }

--- a/src/Hosting/Queue/src/BatchQueueHostedService.cs
+++ b/src/Hosting/Queue/src/BatchQueueHostedService.cs
@@ -49,6 +49,8 @@ public abstract class BatchQueueHostedService<TMessage, TOptions> : BaseQueueHos
         var subscribeOptions = new SubscribeOptions
         {
             PrefetchCount = Options.BatchSize,
+            // We only want to run 1 thread when processing batches
+            ConsumerDispatchConcurrency = 1,
             AutoAcknowledge = false
         };
 
@@ -212,7 +214,7 @@ public abstract class BatchQueueHostedService<TMessage, TOptions> : BaseQueueHos
                     }
                     else
                     {
-                        snapshot = Array.Empty<TMessage>();
+                        snapshot = [];
                         latestDeliveryTag = 0;
                     }
                 }

--- a/src/Hosting/Queue/src/QueueHostedService.cs
+++ b/src/Hosting/Queue/src/QueueHostedService.cs
@@ -28,7 +28,11 @@ public abstract class QueueHostedService<TMessage, TOptions> : BaseQueueHostedSe
     {
         return queueClient.SubscribeAsync<TMessage>(queueName,
             OnMessageInternalAsync,
-            new SubscribeOptions {PrefetchCount = Options.ConcurrentTaskCount},
+            new SubscribeOptions
+            {
+                PrefetchCount = Options.ConcurrentTaskCount,
+                ConsumerDispatchConcurrency = Options.ConcurrentTaskCount
+            },
             cancellationToken);
     }
 

--- a/src/Hosting/Queue/src/QueueHostedServiceOptions.cs
+++ b/src/Hosting/Queue/src/QueueHostedServiceOptions.cs
@@ -5,4 +5,8 @@ namespace ClickView.GoodStuff.Hosting.Queue;
 /// </summary>
 public abstract class QueueHostedServiceOptions : BaseQueueHostedServiceOptions
 {
+    /// <summary>
+    /// The number of tasks to run concurrently.
+    /// </summary>
+    public ushort ConcurrentTaskCount { get; set; } = 1;
 }

--- a/src/Queues/RabbitMq/src/SubscribeOptions.cs
+++ b/src/Queues/RabbitMq/src/SubscribeOptions.cs
@@ -5,5 +5,14 @@ public class SubscribeOptions
     public bool AutoAcknowledge { get; init; }
     public ushort PrefetchCount { get; init; } = 1;
 
+    /// <summary>
+    /// Set to a value greater than one to enable concurrent processing. For a concurrency greater than one,
+    /// tasks will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading.
+    /// If set to null, the value from <see cref="RabbitMqClientOptions"/> will be used.
+    /// </summary>
+    /// <remarks>For concurrency greater than one this removes the guarantee that consumers handle messages in the order they receive them.
+    /// In addition to that consumers need to be thread/concurrency safe.</remarks>
+    public ushort? ConsumerDispatchConcurrency { get; set; }
+
     internal static readonly SubscribeOptions Default = new();
 }


### PR DESCRIPTION
The fix in https://github.com/clickviewapp/GoodStuff/pull/290 is not quite right.

`PrefetchCount` != `ConsumerDispatchConcurrency`. Prefetch count is how many messages to receive before you need to ack to get more. `ConsumerDispatchConcurrency` is how many threads to run the messages on.

If we set `ConsumerDispatchConcurrency` to `PrefetchCount` and prefetch count is large (ie when doing batches) then you'll be creating way too many threads.

Instead, pass `ConsumerDispatchConcurrency` in `SubscribeOptions` and use this to control concurrency and not the `PrefetchCount`