### PR TITLE
Fix tasks hanging when using `QueueHostedService`

### DIFF
--- a/src/Hosting/Queue/src/QueueHostedService.cs
+++ b/src/Hosting/Queue/src/QueueHostedService.cs
@@ -59,9 +59,9 @@ public abstract class QueueHostedService<TMessage, TOptions> : BaseQueueHostedSe
         {
             await OnMessageAsync(new QueueMessage<TMessage>(messageContext), cancellationToken);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Propagate up to caller to handle
+            // Only ignore operation canceled when its us cancelling the task
             throw;
         }
         catch (Exception ex)


### PR DESCRIPTION
Only ignore cancellation exceptions if its our token which cancelled. If something else throw a `OperationCanceledException` or `TaskCancelledException`  (such as a http client timing out) then the exception would be ignored and the task was not ack/nack