### PR TITLE
Support the .vault-token file

### DIFF
--- a/src/Configuration/Vault/src/ConfigurationManagerExtensions.cs
+++ b/src/Configuration/Vault/src/ConfigurationManagerExtensions.cs
@@ -1,5 +1,6 @@
 namespace ClickView.GoodStuff.Configuration.Vault;
 
+using System;
 using Microsoft.Extensions.Configuration;
 
 public static class ConfigurationManagerExtensions
@@ -15,6 +16,8 @@ public static class ConfigurationManagerExtensions
         Action<VaultOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(configurationManager);
+
+        configurationManager.Sources.Insert(0, new VaultTokenFileConfigurationSource());
 
         var options = GetOptions(configurationManager);
 

--- a/src/Configuration/Vault/src/VaultTokenFileConfigurationProvider.cs
+++ b/src/Configuration/Vault/src/VaultTokenFileConfigurationProvider.cs
@@ -1,0 +1,19 @@
+namespace ClickView.GoodStuff.Configuration.Vault;
+
+using Microsoft.Extensions.Configuration;
+
+internal class VaultTokenFileConfigurationProvider : ConfigurationProvider
+{
+    public override void Load()
+    {
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vault-token");
+
+        if (!File.Exists(path))
+            return;
+
+        var token = File.ReadAllText(path).Trim();
+
+        if (!string.IsNullOrEmpty(token))
+            Data["Vault:Token"] = token;
+    }
+}

--- a/src/Configuration/Vault/src/VaultTokenFileConfigurationSource.cs
+++ b/src/Configuration/Vault/src/VaultTokenFileConfigurationSource.cs
@@ -1,0 +1,8 @@
+namespace ClickView.GoodStuff.Configuration.Vault;
+
+using Microsoft.Extensions.Configuration;
+
+internal class VaultTokenFileConfigurationSource : IConfigurationSource
+{
+    public IConfigurationProvider Build(IConfigurationBuilder builder) => new VaultTokenFileConfigurationProvider();
+}


### PR DESCRIPTION
Adds support for reading the Vault token from ~/.vault-token, the file written by the Vault CLI after running `vault login`. This allows developers to run services locally against Vault without needing to manually set environment variables.