### PR TITLE
Support more Snowflake authentication methods

### DIFF
--- a/src/Repositories/Snowflake/src/AwsSnowflakeAuthenticator.cs
+++ b/src/Repositories/Snowflake/src/AwsSnowflakeAuthenticator.cs
@@ -1,0 +1,12 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake;
+
+public class AwsSnowflakeAuthenticator : ISnowflakeAuthenticator
+{
+    public static AwsSnowflakeAuthenticator Instance { get; } = new();
+
+    public void SetOptions(SnowflakeConnectionOptions options)
+    {
+        options.Authenticator = "workload_identity";
+        options.WorkloadIdentityProvider = "aws";
+    }
+}

--- a/src/Repositories/Snowflake/src/ClickView.GoodStuff.Repositories.Snowflake.csproj
+++ b/src/Repositories/Snowflake/src/ClickView.GoodStuff.Repositories.Snowflake.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66"/>
-    <PackageReference Include="Snowflake.Data" Version="5.4.1"/>
+    <PackageReference Include="Snowflake.Data" Version="5.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Repositories/Snowflake/src/ExternalBrowserSnowflakeAuthenticator.cs
+++ b/src/Repositories/Snowflake/src/ExternalBrowserSnowflakeAuthenticator.cs
@@ -1,0 +1,11 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake;
+
+public class ExternalBrowserSnowflakeAuthenticator : ISnowflakeAuthenticator
+{
+    public static ExternalBrowserSnowflakeAuthenticator Instance { get; } = new();
+
+    public void SetOptions(SnowflakeConnectionOptions options)
+    {
+        options.Authenticator = "externalbrowser";
+    }
+}

--- a/src/Repositories/Snowflake/src/ISnowflakeAuthenticator.cs
+++ b/src/Repositories/Snowflake/src/ISnowflakeAuthenticator.cs
@@ -1,0 +1,6 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake;
+
+public interface ISnowflakeAuthenticator
+{
+    public void SetOptions(SnowflakeConnectionOptions options);
+}

--- a/src/Repositories/Snowflake/src/ProgrammaticAccessTokenSnowflakeAuthenticator.cs
+++ b/src/Repositories/Snowflake/src/ProgrammaticAccessTokenSnowflakeAuthenticator.cs
@@ -1,0 +1,20 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake;
+
+public class ProgrammaticAccessTokenSnowflakeAuthenticator : ISnowflakeAuthenticator
+{
+    private readonly string _token;
+
+    public ProgrammaticAccessTokenSnowflakeAuthenticator(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            throw new ArgumentNullException(nameof(token));
+
+        _token = token;
+    }
+
+    public void SetOptions(SnowflakeConnectionOptions options)
+    {
+        options.Authenticator = "programmatic_access_token";
+        options.Token = _token;
+    }
+}

--- a/src/Repositories/Snowflake/src/SnowflakeConnectionFactory.cs
+++ b/src/Repositories/Snowflake/src/SnowflakeConnectionFactory.cs
@@ -3,21 +3,13 @@
 using Abstractions.Factories;
 using global::Snowflake.Data.Client;
 
-public class SnowflakeConnectionFactory : SnowflakeConnectionFactory<SnowflakeConnectionOptions>
-{
-    public SnowflakeConnectionFactory(ConnectionFactoryOptions<SnowflakeConnectionOptions> options) : base(options)
-    {
-    }
-}
+public class SnowflakeConnectionFactory(ConnectionFactoryOptions<SnowflakeConnectionOptions> options)
+    : SnowflakeConnectionFactory<SnowflakeConnectionOptions>(options);
 
-public class SnowflakeConnectionFactory<TOptions>
-    : ConnectionFactory<SnowflakeDbConnection, TOptions>, ISnowflakeConnectionFactory
+public class SnowflakeConnectionFactory<TOptions>(ConnectionFactoryOptions<TOptions> options)
+    : ConnectionFactory<SnowflakeDbConnection, TOptions>(options), ISnowflakeConnectionFactory
     where TOptions : SnowflakeConnectionOptions
 {
-    public SnowflakeConnectionFactory(ConnectionFactoryOptions<TOptions> options) : base(options)
-    {
-    }
-
     public override SnowflakeDbConnection GetReadConnection()
     {
         if (string.IsNullOrEmpty(ReadConnectionString))

--- a/src/Repositories/Snowflake/src/SnowflakeConnectionOptions.cs
+++ b/src/Repositories/Snowflake/src/SnowflakeConnectionOptions.cs
@@ -4,6 +4,15 @@ using Abstractions;
 
 public class SnowflakeConnectionOptions : RepositoryConnectionOptions
 {
+    public SnowflakeConnectionOptions()
+    {
+    }
+
+    public SnowflakeConnectionOptions(ISnowflakeAuthenticator authenticator)
+    {
+        UseAuthenticator(authenticator);
+    }
+
     /// <summary>
     /// The full account name which might include additional segments that identify the region and
     /// cloud platform where your account is hosted
@@ -57,5 +66,34 @@ public class SnowflakeConnectionOptions : RepositoryConnectionOptions
     {
         set => SetParameter("password", value);
         get => GetParameter("password");
+    }
+
+    public string? Authenticator
+    {
+        set => SetParameter("authenticator", value);
+        get => GetParameter("authenticator");
+    }
+
+    /// <summary>
+    /// Used to set the name of the cloud provider when authenticator=workload_identity
+    /// </summary>
+    public string? WorkloadIdentityProvider
+    {
+        set => SetParameter("workload_identity_provider", value);
+        get => GetParameter("workload_identity_provider");
+    }
+
+    /// <summary>
+    /// Used to set the programmatic access token (PAT) when authenticator=programmatic_access_token
+    /// </summary>
+    public string? Token
+    {
+        set => SetParameter("token", value);
+        get => GetParameter("token");
+    }
+
+    public void UseAuthenticator(ISnowflakeAuthenticator authenticator)
+    {
+        authenticator.SetOptions(this);
     }
 }

--- a/src/Repositories/Snowflake/test/AwsSnowflakeAuthenticatorTests.cs
+++ b/src/Repositories/Snowflake/test/AwsSnowflakeAuthenticatorTests.cs
@@ -1,0 +1,17 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake.Tests;
+
+using Xunit;
+
+public class AwsSnowflakeAuthenticatorTests
+{
+    [Fact]
+    public void SetOptions_EmptyOptions_SetsAuthenticatorAndWorkloadIdentityProvider()
+    {
+        var options = new SnowflakeConnectionOptions();
+
+        new AwsSnowflakeAuthenticator().SetOptions(options);
+
+        Assert.Equal("workload_identity", options.Authenticator);
+        Assert.Equal("aws", options.WorkloadIdentityProvider);
+    }
+}

--- a/src/Repositories/Snowflake/test/ExternalBrowserSnowflakeAuthenticatorTests.cs
+++ b/src/Repositories/Snowflake/test/ExternalBrowserSnowflakeAuthenticatorTests.cs
@@ -1,0 +1,16 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake.Tests;
+
+using Xunit;
+
+public class ExternalBrowserSnowflakeAuthenticatorTests
+{
+    [Fact]
+    public void SetOptions_EmptyOptions_SetsAuthenticatorA()
+    {
+        var options = new SnowflakeConnectionOptions();
+
+        new ExternalBrowserSnowflakeAuthenticator().SetOptions(options);
+
+        Assert.Equal("externalbrowser", options.Authenticator);
+    }
+}

--- a/src/Repositories/Snowflake/test/ProgrammaticAccessTokenSnowflakeAuthenticatorTests.cs
+++ b/src/Repositories/Snowflake/test/ProgrammaticAccessTokenSnowflakeAuthenticatorTests.cs
@@ -1,0 +1,17 @@
+namespace ClickView.GoodStuff.Repositories.Snowflake.Tests;
+
+using Xunit;
+
+public class ProgrammaticAccessTokenSnowflakeAuthenticatorTests
+{
+    [Fact]
+    public void SetOptions_EmptyOptions_SetsAuthenticatorAndToken()
+    {
+        var options = new SnowflakeConnectionOptions();
+
+        new ProgrammaticAccessTokenSnowflakeAuthenticator("my-token").SetOptions(options);
+
+        Assert.Equal("programmatic_access_token", options.Authenticator);
+        Assert.Equal("my-token", options.Token);
+    }
+}

--- a/src/Repositories/Snowflake/test/SnowflakeConnectionOptionsTests.cs
+++ b/src/Repositories/Snowflake/test/SnowflakeConnectionOptionsTests.cs
@@ -25,7 +25,10 @@ public class SnowflakeConnectionOptionsTests
             Database = "db",
             Schema = "sch",
             User = "user",
-            Password = "pass"
+            Password = "pass",
+            Authenticator = "auth",
+            WorkloadIdentityProvider = "aws",
+            Token = "tok"
         };
 
         var connString = options.GetConnectionString();
@@ -37,7 +40,10 @@ public class SnowflakeConnectionOptionsTests
             "db=db;" +
             "schema=sch;" +
             "user=user;" +
-            "password=pass;",
+            "password=pass;" +
+            "authenticator=auth;" +
+            "workload_identity_provider=aws;" +
+            "token=tok;",
             connString);
     }
 
@@ -52,7 +58,10 @@ public class SnowflakeConnectionOptionsTests
             Database = "db",
             Schema = "sch",
             User = "user",
-            Password = "pass"
+            Password = "pass",
+            Authenticator = "auth",
+            WorkloadIdentityProvider = "aws",
+            Token = "tok"
         };
 
         Assert.Equal("host", options.Host);
@@ -62,6 +71,9 @@ public class SnowflakeConnectionOptionsTests
         Assert.Equal("sch", options.Schema);
         Assert.Equal("user", options.User);
         Assert.Equal("pass", options.Password);
+        Assert.Equal("auth", options.Authenticator);
+        Assert.Equal("aws", options.WorkloadIdentityProvider);
+        Assert.Equal("tok", options.Token);
     }
 
     [Fact]
@@ -76,6 +88,9 @@ public class SnowflakeConnectionOptionsTests
         Assert.Null(options.Schema);
         Assert.Null(options.User);
         Assert.Null(options.Password);
+        Assert.Null(options.Authenticator);
+        Assert.Null(options.WorkloadIdentityProvider);
+        Assert.Null(options.Token);
     }
 
     [Fact]
@@ -89,7 +104,10 @@ public class SnowflakeConnectionOptionsTests
             Database = null,
             Schema = null,
             User = null,
-            Password = null
+            Password = null,
+            Authenticator = null,
+            WorkloadIdentityProvider = null,
+            Token = null
         };
 
         Assert.Null(options.Host);
@@ -99,5 +117,26 @@ public class SnowflakeConnectionOptionsTests
         Assert.Null(options.Schema);
         Assert.Null(options.User);
         Assert.Null(options.Password);
+        Assert.Null(options.Authenticator);
+        Assert.Null(options.WorkloadIdentityProvider);
+        Assert.Null(options.Token);
+    }
+
+    [Fact]
+    public void Constructor_WithAuthenticator_AppliesAuthenticator()
+    {
+        var options = new SnowflakeConnectionOptions(ExternalBrowserSnowflakeAuthenticator.Instance);
+
+        Assert.Equal("externalbrowser", options.Authenticator);
+    }
+
+    [Fact]
+    public void UseAuthenticator_WithAuthenticator_AppliesAuthenticator()
+    {
+        var options = new SnowflakeConnectionOptions();
+
+        options.UseAuthenticator(ExternalBrowserSnowflakeAuthenticator.Instance);
+
+        Assert.Equal("externalbrowser", options.Authenticator);
     }
 }


### PR DESCRIPTION
- Support more Snowflake authentication methods:
    - Programmatic Access Token
    - Workload Identity Federation
    - Browser-based SSO
- Update to `Snowflake.Data 5.6.0`