### PR TITLE
Bump RabbitMQ.Client package to 7.2.1

### DIFF
--- a/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
+++ b/src/Queues/RabbitMq/src/ClickView.GoodStuff.Queues.RabbitMq.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.2.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Catch all exceptions in HeartbeatWriteTimerCallback and HeartbeatReadTimerCallback to avoid crash
